### PR TITLE
modules/coreboot: update rev to Dasharo v.0.7.0 release for RC Talos II

### DIFF
--- a/modules/coreboot
+++ b/modules/coreboot
@@ -44,7 +44,7 @@ else ifeq "$(CONFIG_COREBOOT_VERSION)" "4.19"
 else ifeq "$(CONFIG_COREBOOT_VERSION)" "talos_2"
 	coreboot_version = git
 	coreboot_patch_version = talos_2
-	coreboot_commit_hash = c8aed443c631042ad2b0326c35cd0b774752b924
+	coreboot_commit_hash = fc47236e9877f4113dfcce07fa928f52d4d2c8ee
 	coreboot_repo := https://github.com/Dasharo/coreboot
 
 else ifeq "$(CONFIG_COREBOOT_VERSION)" "purism"


### PR DESCRIPTION
The diff between these two commits is literally a change in defconfig, so no actual change in terms of codebse from heads perspective, since heads is maintaining defconfig on it's now.