### PR TITLE
flash-gui.sh: Extend NPF archive format to ZIP, improve workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ commands:
           command: |
             ln -fs /usr/share/zoneinfo/America/New_York /etc/localtime
             apt update
-            apt install -y build-essential zlib1g-dev uuid-dev libdigest-sha-perl libelf-dev bc bzip2 bison flex git gnupg gawk iasl m4 nasm patch python python2 python3 wget gnat cpio ccache pkg-config cmake libusb-1.0-0-dev autoconf texinfo ncurses-dev doxygen graphviz udev libudev1 libudev-dev automake libtool rsync innoextract sudo libssl-dev device-tree-compiler u-boot-tools sharutils e2fsprogs parted curl unzip imagemagick libncurses5-dev
+            apt install -y build-essential zlib1g-dev uuid-dev libdigest-sha-perl libelf-dev bc bzip2 bison flex git gnupg gawk iasl m4 nasm patch python python2 python3 wget gnat cpio ccache pkg-config cmake libusb-1.0-0-dev autoconf texinfo ncurses-dev doxygen graphviz udev libudev1 libudev-dev automake libtool rsync innoextract sudo libssl-dev device-tree-compiler u-boot-tools sharutils e2fsprogs parted curl unzip imagemagick libncurses5-dev zip
       - run:
           name: Make Board (FULL ORDERED BUILD LOGS HERE UNTIL JOB FAILED)
           command: |

--- a/Makefile
+++ b/Makefile
@@ -183,9 +183,10 @@ $(board_build)/$(CB_UPDATE_PKG_FILE): $(board_build)/$(CB_OUTPUT_FILE)
 	cp "$<" "$(board_build)/update_pkg/"
 	cd "$(board_build)/update_pkg" && sha256sum "$(CB_OUTPUT_FILE)" >sha256sum.txt
 	cd "$(board_build)/update_pkg" && zip -9 "$@" "$(CB_OUTPUT_FILE)" sha256sum.txt
-endif
 
 all: $(board_build)/$(CB_OUTPUT_FILE) $(board_build)/$(CB_UPDATE_PKG_FILE)
+endif
+
 ifneq ($(CONFIG_COREBOOT_BOOTBLOCK),)
 all: $(board_build)/$(CB_BOOTBLOCK_FILE)
 endif

--- a/Makefile
+++ b/Makefile
@@ -173,6 +173,9 @@ ifeq ($(CONFIG_COREBOOT), y)
 # Legacy flash boards don't generate an update package, the only purpose of
 # those boards is to be flashed over vendor firmware via an exploit.
 ifneq ($(CONFIG_LEGACY_FLASH), y)
+# talos-2 builds its own update package, which is not integrated with the ZIP
+# method currently
+ifneq ($(BOARD), talos-2)
 # Coreboot targets create an update package that can be applied with integrity
 # verification before flashing (see flash-gui.sh).  The ZIP package format
 # allows other metadata that might be needed to added in the future without
@@ -185,6 +188,7 @@ $(board_build)/$(CB_UPDATE_PKG_FILE): $(board_build)/$(CB_OUTPUT_FILE)
 	cd "$(board_build)/update_pkg" && zip -9 "$@" "$(CB_OUTPUT_FILE)" sha256sum.txt
 
 all: $(board_build)/$(CB_OUTPUT_FILE) $(board_build)/$(CB_UPDATE_PKG_FILE)
+endif
 endif
 
 ifneq ($(CONFIG_COREBOOT_BOOTBLOCK),)

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ CB_OUTPUT_BASENAME	:= $(shell echo $(BRAND_NAME) | tr A-Z a-z)-$(BOARD)-$(HEADS_
 CB_OUTPUT_FILE		:= $(CB_OUTPUT_BASENAME).rom
 CB_OUTPUT_FILE_GPG_INJ	:= $(CB_OUTPUT_BASENAME)-gpg-injected.rom
 CB_BOOTBLOCK_FILE	:= $(CB_OUTPUT_BASENAME).bootblock
+CB_UPDATE_PKG_FILE	:= $(CB_OUTPUT_BASENAME).zip
 LB_OUTPUT_FILE		:= linuxboot-$(BOARD)-$(HEADS_GIT_VERSION).rom
 
 all:
@@ -57,11 +58,6 @@ CONFIG_TARGET_ARCH := x86
 CONFIG_LEGACY_FLASH := n
 
 include $(CONFIG)
-
-# Default update package extension is 'zip' unless a brand wants a branded
-# extension
-CONFIG_BRAND_UPDATE_PKG_EXT ?= zip
-CB_UPDATE_PKG_FILE := $(CB_OUTPUT_BASENAME).$(CONFIG_BRAND_UPDATE_PKG_EXT)
 
 # Unless otherwise specified, we are building for heads
 CONFIG_HEADS	?= y

--- a/boards/UNTESTED_t430-legacy-flash/UNTESTED_t430-legacy-flash.config
+++ b/boards/UNTESTED_t430-legacy-flash/UNTESTED_t430-legacy-flash.config
@@ -30,6 +30,8 @@ export CONFIG_BOOTSCRIPT=/bin/xx30-flash.init
 export CONFIG_BOARD_NAME="ThinkPad T430-legacy-flash"
 export CONFIG_FLASHROM_OPTIONS="--force --noverify-all -p internal --ifd --image bios"
 
+CONFIG_LEGACY_FLASH=y
+
 # This board is "special" in that we need a 4MB top SPI flashable ROM.
 # This is enough to allow the board to boot into a minimal Heads and read the full Legacy
 # ROM from an external USB media.

--- a/boards/talos-2/talos-2.config
+++ b/boards/talos-2/talos-2.config
@@ -64,6 +64,6 @@ $(board_build)/$(OUTPUT_PREFIX).tgz: \
 	rm -rf $(board_build)/pkg # cleanup in case directory exists
 	mkdir $(board_build)/pkg
 	cp $^ $(board_build)/pkg
-	cd $(board_build)/pkg && sha256sum * > hashes.txt
+	cd $(board_build)/pkg && sha256sum * > sha256sum.txt
 	cd $(board_build)/pkg && tar zcf $@ *
 	rm -r $(board_build)/pkg

--- a/boards/x230-legacy-flash/x230-legacy-flash.config
+++ b/boards/x230-legacy-flash/x230-legacy-flash.config
@@ -31,6 +31,8 @@ export CONFIG_BOOTSCRIPT=/bin/xx30-flash.init
 export CONFIG_BOARD_NAME="ThinkPad X230-legacy-flash"
 export CONFIG_FLASHROM_OPTIONS="--force --noverify-all -p internal --ifd --image bios"
 
+CONFIG_LEGACY_FLASH=y
+
 # This board is "special" in that we need a 4MB top SPI flashable ROM.
 # This is enough to allow the board to boot into a minimal Heads and read the full Legacy
 # ROM from an external USB media.

--- a/create-npf.sh
+++ b/create-npf.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-set -exuo pipefail
-HEADS_GIT_VERSION=$(git describe --tags)
-BOARD=$1
-cd ./build/x86/${BOARD}/
-sha256sum heads-${BOARD}-${HEADS_GIT_VERSION}.rom > sha256sum.txt
-sed -ie 's@  @  /tmp/verified_rom/@g' sha256sum.txt
-zip heads-${BOARD}-${HEADS_GIT_VERSION}.npf heads-${BOARD}-${HEADS_GIT_VERSION}.rom sha256sum.txt

--- a/initrd/bin/flash-gui.sh
+++ b/initrd/bin/flash-gui.sh
@@ -63,7 +63,11 @@ while true; do
       --yesno "You will need to insert a USB drive containing your BIOS image (*.$UPDATE_PKG_EXT or\n*.$UPDATE_PLAIN_EXT).\n\nAfter you select this file, this program will reflash your BIOS.\n\nDo you want to proceed?" 0 80); then
       mount_usb
       if grep -q /media /proc/mounts; then
-        find /media ! -path '*/\.*' -type f \( -name "*.$UPDATE_PLAIN_EXT" -o -type f -name "*.$UPDATE_PKG_EXT" \) | sort >/tmp/filelist.txt
+        if [ "${CONFIG_BOARD%_*}" = talos-2 ]; then
+          find /media ! -path '*/\.*' -type f -name "*.$UPDATE_PLAIN_EXT" | sort >/tmp/filelist.txt
+        else
+          find /media ! -path '*/\.*' -type f \( -name "*.$UPDATE_PLAIN_EXT" -o -type f -name "*.$UPDATE_PKG_EXT" \) | sort >/tmp/filelist.txt
+        fi
         file_selector "/tmp/filelist.txt" "Choose the ROM to flash"
         if [ "$FILE" == "" ]; then
           exit 1
@@ -109,12 +113,19 @@ while true; do
           # Continue on using the verified ROM
           ROM="$PACKAGE_ROM"
         else
+          # talos-2 uses a .tgz file for its "plain" update, contains other parts as well, validated against hashes under flash.sh
+          # Skip prompt for hash validation for talos-2. Only method is through tgz or through bmc with individual parts
+          if [ "${CONFIG_BOARD%_*}" != talos-2 ]; then
           # a rom file was provided. exit if we shall not proceed
           ROM="$PKG_FILE"
           ROM_HASH=$(sha256sum "$ROM" | awk '{print $1}') || die "Failed to hash ROM file"
           if ! (whiptail $CONFIG_ERROR_BG_COLOR --title 'Flash ROM without integrity check?' \
             --yesno "You have provided a *.$UPDATE_PLAIN_EXT file. The integrity of the file can not be\nchecked automatically for this file type.\n\nROM: $ROM\nSHA256SUM: $ROM_HASH\n\nIf you do not know how to check the file integrity yourself,\nyou should use a *.$UPDATE_PKG_EXT file instead.\n\nIf the file is damaged, you will not be able to boot anymore.\nDo you want to proceed flashing without file integrity check?" 0 80); then
             exit 1
+            fi
+          else
+            #We are on talos-2, so we have a tgz file. We will pass it directly to flash.sh which will take care of it
+            ROM="$PKG_FILE"
           fi
         fi
 

--- a/initrd/bin/flash-gui.sh
+++ b/initrd/bin/flash-gui.sh
@@ -13,9 +13,6 @@ if [ "$CONFIG_RESTRICTED_BOOT" = y ]; then
   exit 1
 fi
 
-# A brand can override the extension used for update packages if desired
-UPDATE_PKG_EXT="${CONFIG_BRAND_UPDATE_PKG_EXT:-zip}"
-
 # Most boards use a .rom file as a "plain" update, contents of the BIOS flash
 UPDATE_PLAIN_EXT=rom
 # talos-2 uses a .tgz file for its "plain" update, contains other parts as well
@@ -60,13 +57,13 @@ while true; do
     ;;
   f | c)
     if (whiptail $BG_COLOR_WARNING --title 'Flash the BIOS with a new ROM' \
-      --yesno "You will need to insert a USB drive containing your BIOS image (*.$UPDATE_PKG_EXT or\n*.$UPDATE_PLAIN_EXT).\n\nAfter you select this file, this program will reflash your BIOS.\n\nDo you want to proceed?" 0 80); then
+      --yesno "You will need to insert a USB drive containing your BIOS image (*.zip or\n*.$UPDATE_PLAIN_EXT).\n\nAfter you select this file, this program will reflash your BIOS.\n\nDo you want to proceed?" 0 80); then
       mount_usb
       if grep -q /media /proc/mounts; then
         if [ "${CONFIG_BOARD%_*}" = talos-2 ]; then
           find /media ! -path '*/\.*' -type f -name "*.$UPDATE_PLAIN_EXT" | sort >/tmp/filelist.txt
         else
-          find /media ! -path '*/\.*' -type f \( -name "*.$UPDATE_PLAIN_EXT" -o -type f -name "*.$UPDATE_PKG_EXT" \) | sort >/tmp/filelist.txt
+          find /media ! -path '*/\.*' -type f \( -name "*.$UPDATE_PLAIN_EXT" -o -type f -name "*.zip" \) | sort >/tmp/filelist.txt
         fi
         file_selector "/tmp/filelist.txt" "Choose the ROM to flash"
         if [ "$FILE" == "" ]; then
@@ -76,7 +73,7 @@ while true; do
         fi
 
         # is an update package provided?
-        if [ -z "${PKG_FILE##*.$UPDATE_PKG_EXT}" ]; then
+        if [ -z "${PKG_FILE##*.zip}" ]; then
           # Unzip the package
           PKG_EXTRACT="/tmp/flash_gui/update_package"
           rm -rf "$PKG_EXTRACT"
@@ -120,7 +117,7 @@ while true; do
           ROM="$PKG_FILE"
           ROM_HASH=$(sha256sum "$ROM" | awk '{print $1}') || die "Failed to hash ROM file"
           if ! (whiptail $CONFIG_ERROR_BG_COLOR --title 'Flash ROM without integrity check?' \
-            --yesno "You have provided a *.$UPDATE_PLAIN_EXT file. The integrity of the file can not be\nchecked automatically for this file type.\n\nROM: $ROM\nSHA256SUM: $ROM_HASH\n\nIf you do not know how to check the file integrity yourself,\nyou should use a *.$UPDATE_PKG_EXT file instead.\n\nIf the file is damaged, you will not be able to boot anymore.\nDo you want to proceed flashing without file integrity check?" 0 80); then
+            --yesno "You have provided a *.$UPDATE_PLAIN_EXT file. The integrity of the file can not be\nchecked automatically for this file type.\n\nROM: $ROM\nSHA256SUM: $ROM_HASH\n\nIf you do not know how to check the file integrity yourself,\nyou should use a *.zip file instead.\n\nIf the file is damaged, you will not be able to boot anymore.\nDo you want to proceed flashing without file integrity check?" 0 80); then
             exit 1
             fi
           else

--- a/initrd/bin/flash.sh
+++ b/initrd/bin/flash.sh
@@ -180,7 +180,7 @@ if [ "$READ" -eq 0 ] && [ "${ROM##*.}" = tgz ]; then
         mkdir /tmp/verified_rom
 
         tar -C /tmp/verified_rom -xf $ROM || die "Rom archive $ROM could not be extracted"
-        if ! (cd /tmp/verified_rom/ && sha256sum -cs hashes.txt); then
+    if ! (cd /tmp/verified_rom/ && sha256sum -cs sha256sum.txt); then
             die "Provided tgz image did not pass hash verification"
         fi
 


### PR DESCRIPTION
The NPF file extension can be configured on a per-board basis, default is ZIP.  Fixed some issues in the implementation (don't require /tmp/verified_rom/ in sha256sum.txt, show integrity error instead of dying if ZIP itself is corrupt as that is more likely, etc.), details in commit messages.

Update package is built in default target now, removed create_npf.sh.

@daringer This should still be compatible with any npf archives already published (/tmp/verified_rom/ prefix is removed if present).  Do you want `export CONFIG_BRAND_UPDATE_PKG_EXT=npf` added to your boards?

@tlaurion I refactored prompts a little so .tgz only appears for talos-2 (and .rom does not appear on talos-2).  I can't really do any further refactoring to better integrate talos-2 with the zip method.  If you want to improve anything there I'm happy to review/discuss, we could also merge this and improve later as this is better than the current master for all boards.

So help me, I added a confirmation prompt :scream:  zip/npf somehow ended up without one, went straight to flash after the file selector.  It's just too easy IMO to accidentally select the wrong file, and flashing is sensitive/irreversible.  I brought back the prompt message from before the NPF introduction.

The prompt after rebooting now shows the file that was selected, not the file that was flashed (which is some temp file when selecting an update package).

The .rom prompt is unchanged, I expect to carry a patch downstream in PureBoot for a while softening the message there until we are confident that .zip support has rolled out widely enough to switch to it.