### PR TITLE
oem-factory-reset: kill scdaemon after aes regenerate on nk storage

### DIFF
--- a/initrd/bin/oem-factory-reset
+++ b/initrd/bin/oem-factory-reset
@@ -497,6 +497,7 @@ gpg_key_factory_reset() {
     # If Nitrokey Storage is inserted, reset AES keys as well
     if lsusb | grep -q "20a0:4109" && [ -x /bin/hotp_verification ]; then
         /bin/hotp_verification regenerate ${ADMIN_PIN_DEF}
+        killall -9 scdaemon
     fi
     # Toggle forced sig (good security practice, forcing PIN request for each signature request)
     if gpg --card-status | grep "Signature PIN" | grep -q "not forced"; then


### PR DESCRIPTION
The call to `hotp_verification regenerate` seems to leave the communication in a bad state, thus the following `gpg` calls fail. With this workaround `scdaemon` will resart with the next `gpg` call.
