### PR TITLE
Luks functions text patch & change order of reencrypt and passphrase change

### DIFF
--- a/initrd/bin/oem-factory-reset
+++ b/initrd/bin/oem-factory-reset
@@ -1148,8 +1148,8 @@ fi
 
 if [ -n "$luks_new_Disk_Recovery_Key_desired" -a -n "$luks_new_Disk_Recovery_Key_passphrase_desired" ]; then
     #Reencryption of disk, disk recovery key and Disk Recovery Key passphrase change is requested
-    luks_reencrypt
     luks_change_passphrase
+    luks_reencrypt
 elif [ -n "$luks_new_Disk_Recovery_Key_desired" -a -z "$luks_new_Disk_Recovery_Key_passphrase_desired" ]; then
     #Reencryption of disk was requested but not passphrase change
     luks_reencrypt

--- a/initrd/etc/luks-functions
+++ b/initrd/etc/luks-functions
@@ -300,20 +300,20 @@ test_luks_current_disk_recovery_key_passphrase()
 		select_luks_container || return 1
 		if [ -z "$luks_current_Disk_Recovery_Key_passphrase" ]; then
 			#if no external provisioning provides current Disk Recovery Key passphrase
-			echo -e "\nEnter current Disk Recovery Key passphrase (Configured at OS installation or by OEM):"
+			echo -e "\nEnter the current Disk Recovery Key passphrase (Configured at OS installation or by OEM):"
 			read -r luks_current_Disk_Recovery_Key_passphrase
 			echo -n "$luks_current_Disk_Recovery_Key_passphrase" >/tmp/luks_current_Disk_Recovery_Key_passphrase
-			warn "Test opening "$LUKS" LUKS encrypted drive content with current Recovery Disk Key passphrase..."
+			warn "Testing opening "$LUKS" LUKS encrypted drive content with the current Disk Recovery Key passphrase..."
 			cryptsetup open $LUKS test --key-file /tmp/luks_current_Disk_Recovery_Key_passphrase
 		else
 			echo -n "$luks_current_Disk_Recovery_Key_passphrase" >/tmp/luks_current_Disk_Recovery_Key_passphrase
-			warn "Test opening "$LUKS" LUKS encrypted drive content with current Recovery Disk Key passphrase..."
+			warn "Testing opening "$LUKS" LUKS encrypted drive content with the current Disk Recovery Key passphrase..."
 			cryptsetup open $LUKS test --key-file /tmp/luks_current_Disk_Recovery_Key_passphrase
 		fi
 		#Validate past cryptsetup-reencrypt attempts
 		if [ $? -eq 0 ]; then
 			whiptail --title 'Invalid Actual LUKS Disk Recovery Key passphrase?' --msgbox \
-				"If you previously changed it and do not remember it, you will have to\n reinstall OS from a an external drive.\n\nTo do so, place ISO file and its signature file on root of external drive,\n and select Options-> Boot from USB \n\nHit Enter to retry." 30 60
+				"If you previously changed it and do not remember it, you will have to\n reinstall the OS from a an external drive.\n\nTo do so, place the ISO file and its signature file on root of an\n external drive, and select Options-> Boot from USB \n\nHit Enter to retry." 30 60
 			shred -n 10 -z -u /tmp/luks_current_Disk_Recovery_Key_passphrase 2>/dev/null
 			#unsetting luks_current_Disk_Recovery_Key_passphrase so we prompt for it again Disk Recovery Key passphrase prompt on next round
 			unset luks_current_Disk_Recovery_Key_passphrase
@@ -339,24 +339,28 @@ luks_reencrypt() {
 	TRACE "Under /etc/luks-functions:luks_reencrypt()"
 	while :; do
 		select_luks_container || return 1
+                #If the user just set a new Disk Recovery Key passphrase
+                if [ -n "$luks_new_Disk_Recovery_Key_passphrase" ]; then
+                        luks_current_Disk_Recovery_Key_passphrase="$luks_new_Disk_Recovery_Key_passphrase"
+                fi
 		if [ -z "$luks_current_Disk_Recovery_Key_passphrase" ]; then
 			#if no external provisioning provides current Disk Recovery Key passphrase
-			whiptail --title 'Reencrypt LUKS disk encrypted container ?' \
-			--msgbox "This will replace the encrypted container content and its Disk Recovery Key.\n\nThe passphrase associated with this key will be asked from the user in the\nfollowing conditions:\n 1-Every boot if no Disk unlock key was added to the TPM\n 2-If the TPM fails (Hardware failure)\n 3-If the firmware has been tampered with/upgraded/modified by the user\n\nThis process requires you to type the current Disk Recovery Key passphrase\nand will delete TPM Disk unlock key slot if set up by setting a default boot\n LUKS header (slot 1) if present.\n\nAt the next prompt, you may be asked to select which file corresponds to\nthe LUKS device container.\n\nHit Enter to continue." 0 80
-			echo -e "\nEnter current Disk Recovery Key passphrase (Configured at OS installation or by OEM):"
+			whiptail --title 'Reencrypt LUKS encrypted container ?' \
+			--msgbox "This will replace the encrypted container content and its Disk Recovery Key.\n\nThe passphrase associated with this key will be asked from the user under\nthe following conditions:\n 1-Every boot if no Disk Unlock Key was added to the TPM\n 2-If the TPM fails (hardware failure)\n 3-If the firmware has been tampered with/upgraded/modified by the user\n\nThis process requires you to type the current Disk Recovery Key passphrase\nand will delete the TPM Disk Unlock Key slot, if set up, by setting a default\n boot LUKS key slot (1) if present.\n\nAt the next prompt, you may be asked to select which file corresponds to\nthe LUKS device container.\n\nHit Enter to continue." 0 80
+			echo -e "\nEnter the current Disk Recovery Key passphrase:"
 			read -r luks_current_Disk_Recovery_Key_passphrase
 			echo -n "$luks_current_Disk_Recovery_Key_passphrase" >/tmp/luks_current_Disk_Recovery_Key_passphrase
-			warn "Reencrypting "$LUKS" LUKS encrypted drive content with current Recovery Disk Key passphrase..."
+			warn "Reencrypting "$LUKS" LUKS encrypted drive content with a new Disk Recovery Key. Do NOT shut down or reboot!"
 			cryptsetup-reencrypt -B 64 --use-directio "$LUKS" --key-slot 0 --key-file /tmp/luks_current_Disk_Recovery_Key_passphrase
 		else
 			echo -n "$luks_current_Disk_Recovery_Key_passphrase" >/tmp/luks_current_Disk_Recovery_Key_passphrase
-			warn "Reencrypting "$LUKS" LUKS encrypted drive content with current Recovery Disk Key passphrase..."
+			warn "Reencrypting "$LUKS" LUKS encrypted drive content with a new Disk Recovery Key. Do NOT shut down or reboot!"
 			cryptsetup-reencrypt -B 64 --use-directio "$LUKS" --key-slot 0 --key-file /tmp/luks_current_Disk_Recovery_Key_passphrase
 		fi
 		#Validate past cryptsetup-reencrypt attempts
 		if [ $(echo $?) -ne 0 ]; then
 			whiptail --title 'Invalid Actual LUKS Disk Recovery Key passphrase?' --msgbox \
-				"If you previously changed it and do not remember it, you will have to\n reinstall OS from a an external drive.\n\nTo do so, place ISO file and its signature file on root of external drive,\n and select Options-> Boot from USB \n\nHit Enter to retry." 30 60
+				"If you previously changed it and do not remember it, you will have to\n reinstall the OS from a an external drive.\n\nTo do so, place the ISO file and its signature file on root of an\n external drive, and select Options-> Boot from USB \n\nHit Enter to retry." 30 60
 			shred -n 10 -z -u /tmp/luks_current_Disk_Recovery_Key_passphrase 2>/dev/null
 			#unsetting luks_current_Disk_Recovery_Key_passphrase so we prompt for it again Disk Recovery Key passphrase prompt on next round
 			unset luks_current_Disk_Recovery_Key_passphrase
@@ -383,29 +387,29 @@ luks_change_passphrase()
 		#if actual or new Disk Recovery Key is not provisioned by oem-provisioning file
 		if [ -z "$luks_current_Disk_Recovery_Key_passphrase" ] || [ -z "$luks_new_Disk_Recovery_Key_passphrase" ]; then
 			whiptail --title 'Changing LUKS Disk Recovery Key passphrase' --msgbox \
-				"Please enter current Disk Recovery Key passphrase (slot 0).\nThen choose a strong passphrase of your own.\n\n**DICEWARE passphrase methodology is STRONGLY ADVISED.**\n\nHit Enter to continue" 30 60
+				"Please enter the current Disk Recovery Key passphrase (slot 0).\nThen choose a strong passphrase of your own.\n\n**DICEWARE passphrase methodology is STRONGLY ADVISED.**\n\nHit Enter to continue" 30 60
 			if [ -z "$luks_new_Disk_Recovery_Key_passphrase" ]; then
-				echo -e "\nEnter desired replacement for actual Disk Recovery Key passphrase (At least 8 characters long):"
+				echo -e "\nEnter your desired replacement for the actual Disk Recovery Key passphrase (At least 8 characters long):"
 				while [[ ${#luks_new_Disk_Recovery_Key_passphrase} -lt 8 ]]; do
-					{
-						read -r luks_new_Disk_Recovery_Key_passphrase
-			};done
+				{
+					read -r luks_new_Disk_Recovery_Key_passphrase
+			        };done
 			fi
 			if [ -z "$luks_current_Disk_Recovery_Key_passphrase" ]; then
-				echo -e "\nEnter current Disk Recovery Key passphrase (Configured at OS installation or by OEM):"
+				echo -e "\nEnter the current Disk Recovery Key passphrase (Configured at OS installation or by OEM):"
 				read -r luks_current_Disk_Recovery_Key_passphrase
 			fi
 			export luks_current_Disk_Recovery_Key_passphrase
 			export luks_new_Disk_Recovery_Key_passphrase
 			echo -n "$luks_new_Disk_Recovery_Key_passphrase" >/tmp/luks_new_Disk_Recovery_Key_passphrase
 			echo -n "$luks_current_Disk_Recovery_Key_passphrase" >/tmp/luks_current_Disk_Recovery_Key_passphrase
-			warn "Changing "$LUKS" LUKS encrypted disk passphrase to new Disk Recovery Key passphrase..."
+			warn "Changing "$LUKS" LUKS encrypted disk passphrase to the new Disk Recovery Key passphrase..."
 			cryptsetup luksChangeKey "$LUKS" --key-slot 0 --key-file=/tmp/luks_current_Disk_Recovery_Key_passphrase /tmp/luks_new_Disk_Recovery_Key_passphrase
 		else
 			#If current and new Disk Recovery Key were exported
 			echo -n "$luks_new_Disk_Recovery_Key_passphrase" >/tmp/luks_new_Disk_Recovery_Key_passphrase
 			echo -n "$luks_current_Disk_Recovery_Key_passphrase" >/tmp/luks_current_Disk_Recovery_Key_passphrase
-			warn "Changing "$LUKS" LUKS encrypted disk passphrase to new Disk Recovery Key passphrase..."
+			warn "Changing "$LUKS" LUKS encrypted disk passphrase to the new Disk Recovery Key passphrase..."
 			cryptsetup luksChangeKey "$LUKS" --key-slot 0 --key-file=/tmp/luks_current_Disk_Recovery_Key_passphrase /tmp/luks_new_Disk_Recovery_Key_passphrase
 		fi
 
@@ -413,7 +417,7 @@ luks_change_passphrase()
 		if [ $(echo $?) -ne 0 ]; then
 			#Cryptsetup luksChangeKey was unsuccessful
 			whiptail --title 'Invalid LUKS passphrase?' --msgbox \
-				"The LUKS Disk Recovery Key passphrase was provided to you by the OEM over\n secure communication channel.\n\nIf you previously changed it and do not remember it,\n you will have to reinstall OS from a USB drive.\nTo do so, put OS ISO file and it's signature file on root of USB drive,\n And select Boot from USB\n\nHit Enter to continue." 30 60
+				"The LUKS Disk Recovery Key passphrase was provided to you by the OEM over\n a secure communication channel.\n\nIf you previously changed it and do not remember it,\n you will have to reinstall the OS from a USB drive.\nTo do so, put OS ISO file and it's signature file on root of a USB drive,\n and select Boot from USB\n\nHit Enter to continue." 30 60
 			unset luks_current_Disk_Recovery_Key_passphrase
 			unset luks_new_Disk_Recovery_Key_passphrase
 			#remove "known good" selected LUKS container so that next pass asks again user to select LUKS container.


### PR DESCRIPTION
Fixes point 3. from #1539 and other minor points in discussion there. Summary of changes:

1. If user selects both reencrypt and change passphrase during OEM factory reset, then the passphrase will be changed first so as not to leave a copy of the new volume key encrypted with potentially compromised defaults (e.g. "PleaseChangeMe" passphrase from OEM) lying around on disk if disk is COW media such as SSD and does not garbage collect properly. This fixes point 3. from #1539.
2. Added check for exported new passphrase to reencrypt function, so that it uses the new one if it was set.
3. Removed all instances of incorrect term "Recovery Disk Key" and replaced with "Disk Recovery Key".
4. Changed the warning message of reencrypt function to better reflect the process and warn user not to reboot or shut off, which is especially important if we will use `--resilience=none` in the future.
5. Replaced occurrences of "TPM Disk unlock key" with "TPM Disk Unlock Key" to be more consistent with naming conventions.
6. Fixed a lot of grammatical errors.