### PR TITLE
Use a wider window to show the secrets

### DIFF
--- a/initrd/bin/oem-factory-reset
+++ b/initrd/bin/oem-factory-reset
@@ -1326,8 +1326,8 @@ fi
 
 ## Show to user current configured secrets prior of rebooting
 whiptail --msgbox "
-    $passphrases" \
-    $HEIGHT $(($WIDTH*2)) --title "Configured secrets"
+    $(echo "$passphrases" | fold -w $((WIDTH-20)))" \
+    $HEIGHT $WIDTH --title "Configured secrets"
 
 ## all done -- reboot
 whiptail --msgbox "

--- a/initrd/bin/oem-factory-reset
+++ b/initrd/bin/oem-factory-reset
@@ -1326,7 +1326,7 @@ fi
 
 ## Show to user current configured secrets prior of rebooting
 whiptail --msgbox "
-    $(echo "$passphrases" | fold -w $((WIDTH-20)))" \
+    $(echo -e "$passphrases" | fold -w $((WIDTH-5)))" \
     $HEIGHT $WIDTH --title "Configured secrets"
 
 ## all done -- reboot

--- a/initrd/bin/oem-factory-reset
+++ b/initrd/bin/oem-factory-reset
@@ -1327,7 +1327,7 @@ fi
 ## Show to user current configured secrets prior of rebooting
 whiptail --msgbox "
     $passphrases" \
-    $HEIGHT $WIDTH --title "Configured secrets"
+    $HEIGHT $(($WIDTH*2)) --title "Configured secrets"
 
 ## all done -- reboot
 whiptail --msgbox "


### PR DESCRIPTION
This partially fixes #1537, but while the increased width wouldn't be a problem on the NV41 AFAICT, I don't know about other machines.

I don't know what @tlaurion means with "busybox's folding", which may be a better solution.