### PR TITLE
CircleCI: add layer2 cache of newly added coreboot git forks to speedup builds from cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -258,7 +258,7 @@ workflows:
       - save_cache:
           requires:
             - talos-2
-            - nitropad-nv41
+            - librem_14
 
 #
 # Those onboarding new boards should add their entries below.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,8 +194,10 @@ jobs:
             - build/x86/coreboot-4.15
             - build/x86/coreboot-4.17
             - build/x86/coreboot-4.19
-            - build/x86/coreboot-git
-            - build/ppc64/coreboot-git
+            - build/x86/coreboot-dasharo-kgpe-d16
+            - build/x86/coreboot-nitrokey
+            - build/x86/coreboot-purism
+
       - save_cache:
           #Generate cache for the exact same modules definitions if hash is not previously existing
           key: heads-modules-and-patches-{{ checksum "./tmpDir/all_modules_and_patches.sha256sums" }}{{ .Environment.CACHE_VERSION }}


### PR DESCRIPTION
Master doesn't currently caches nor reuses coreboot's git forks build dir cache (layer2) but if no modules config changed (layer3). 

So cache coreboot git dirs so that crossgcc toolchain can be built once and reuse when cache layer3 is invalidated by other modules having changed bu coreboot hasn't to speed up builds from cache of coreboot build dir which should be reused to only compile new modules having changed.

As of today, cache layer 3 (only scripts having changed) encompassed all build dirs and was reused. 

Reminder
- cache layer 1: always reuse musl-cross-make measuring modules/musl file hash for reusal 
- cache layer 2: coreboot build cache + musl-cross-make measuring modules/coreboot+modules/musl for reusal
- cache layer 3: all build dir cache measuring Makefile and modules files for reusal