### PR TITLE
Automate blobs download for xx30 xx20 boards

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,6 +96,12 @@ jobs:
             ./blobs/xx20/download_parse_me.sh
 
       - run:
+          name: Download and neuter xx30 ME (keep generated GBE and extracted IFD in tree)
+          # me_cleaner.py present under heads xx30 blobs dir comes from https://github.com/corna/me_cleaner/blob/43612a630c79f3bc6f2653bfe90dfe0b7b137e08/me_cleaner.py
+          command: |
+            ./blobs/xx30/download_clean_me_manual.sh -m $(readlink -f ./blobs/xx30/me_cleaner.py)
+
+      - run:
           name: Download and extract t530 vbios roms for dgpu boards
           command: |
             ./blobs/xx30/vbios_t530.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,22 +95,6 @@ jobs:
           command: |
             ./blobs/xx20/download_parse_me.sh
 
-      - run:
-          name: Download and neuter xx30 ME (keep generated GBE and extracted IFD in tree)
-          # me_cleaner.py present under heads xx30 blobs dir comes from https://github.com/corna/me_cleaner/blob/43612a630c79f3bc6f2653bfe90dfe0b7b137e08/me_cleaner.py
-          command: |
-            ./blobs/xx30/download_clean_me_manual.sh -m $(readlink -f ./blobs/xx30/me_cleaner.py)
-
-      - run:
-          name: Download and extract t530 vbios roms for dgpu boards
-          command: |
-            ./blobs/xx30/vbios_t530.sh
-
-      - run:
-          name: Download and extract w530 vbios roms for dgpu boards
-          command: |
-            ./blobs/xx30/vbios_w530.sh
-
       - persist_to_workspace:
           root: ~/
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,12 +96,6 @@ jobs:
             ./blobs/xx20/download_parse_me.sh
 
       - run:
-          name: Download and neuter xx30 ME (keep generated GBE and extracted IFD in tree)
-          # me_cleaner.py present under heads xx30 blobs dir comes from https://github.com/corna/me_cleaner/blob/43612a630c79f3bc6f2653bfe90dfe0b7b137e08/me_cleaner.py
-          command: |
-            ./blobs/xx30/download_clean_me.sh -m $(readlink -f ./blobs/xx30/me_cleaner.py)
-
-      - run:
           name: Download and extract t530 vbios roms for dgpu boards
           command: |
             ./blobs/xx30/vbios_t530.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,10 +90,6 @@ jobs:
             #If precedent cache not found. Restore cache for musl-cross-make module digest (rarely modified).
             #Otherwise, we build cleanly.
             - heads-musl-cross-{{ checksum "./tmpDir/musl-cross.sha256sums" }}{{ .Environment.CACHE_VERSION }}
-      - run:
-          name: Download and neuter xx20 ME (keep generated GBE and extracted IFD in tree)
-          command: |
-            ./blobs/xx20/download_parse_me.sh
 
       - persist_to_workspace:
           root: ~/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,6 +90,26 @@ jobs:
             #If precedent cache not found. Restore cache for musl-cross-make module digest (rarely modified).
             #Otherwise, we build cleanly.
             - heads-musl-cross-{{ checksum "./tmpDir/musl-cross.sha256sums" }}{{ .Environment.CACHE_VERSION }}
+      - run:
+          name: Download and neuter xx20 ME (keep generated GBE and extracted IFD in tree)
+          command: |
+            ./blobs/xx20/download_parse_me.sh
+
+      - run:
+          name: Download and neuter xx30 ME (keep generated GBE and extracted IFD in tree)
+          # me_cleaner.py present under heads xx30 blobs dir comes from https://github.com/corna/me_cleaner/blob/43612a630c79f3bc6f2653bfe90dfe0b7b137e08/me_cleaner.py
+          command: |
+            ./blobs/xx30/download_clean_me_manually.sh -m $(readlink -f ./blobs/xx30/me_cleaner.py)
+
+      - run:
+          name: Download and extract t530 vbios roms for dgpu boards
+          command: |
+            ./blobs/xx30/vbios_t530.sh
+
+      - run:
+          name: Download and extract w530 vbios roms for dgpu boards
+          command: |
+            ./blobs/xx30/vbios_w530.sh
 
       - persist_to_workspace:
           root: ~/

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ $(error "Unexpected value of $$(CONFIG_TARGET_ARCH): $(CONFIG_TARGET_ARCH)")
 endif
 
 ifneq "$(BOARD_TARGETS)" ""
-include targets/$(BOARD_TARGETS).mk
+include $(foreach TARGET,$(BOARD_TARGETS),targets/$(TARGET).mk)
 endif
 
 # Create directories if they don't already exist

--- a/blobs/xx20/download_parse_me.sh
+++ b/blobs/xx20/download_parse_me.sh
@@ -6,10 +6,20 @@ FINAL_ME_BIN_SHA256SUM="1eef6716aa61dd844d58eca15a85faa1bf5f82715defd30bd3373e79
 ME_EXE_SHA256SUM="48f18d49f3c7c79fa549a980f14688bc27c18645f64d9b6827a15ef5c547d210  83rf46ww.exe"
 ME7_5M_UPD_PRODUCTION_SHA256SUM="760b0776b99ba94f56121d67c1f1226c77f48bd3b0799e1357a51842c79d3d36  app/ME7_5M_UPD_Production.bin"
 
+if [ -e "$BLOBDIR/me.bin" ]; then
+  echo "$BLOBDIR/me.bin found..."
+  if ! echo "$FINAL_ME_BIN_SHA256SUM" | sha256sum --check; then
+    echo "$BLOBDIR/me.bin doesn't pass integrity validation. Continuing..."
+    rm -f "$BLOBDIR/me.bin"
+  else
+    echo "$BLOBDIR/me.bin already extracted and neutered outside of BUP"
+    exit 0
+  fi
+fi
 
 echo "### Creating temp dir"
 extractdir=$(mktemp -d)
-cd "$extractdir"
+cd "$extractdir" || exit 1
 
 echo "### Downloading https://download.lenovo.com/ibmdl/pub/pc/pccbbs/mobiles/83rf46ww.exe..."
 wget  https://download.lenovo.com/ibmdl/pub/pc/pccbbs/mobiles/83rf46ww.exe || { echo "ERROR: wget not found" && exit 1; }
@@ -23,13 +33,13 @@ echo "### Verifying expected hash of app/ME7_5M_UPD_Production.bin"
 echo "$ME7_5M_UPD_PRODUCTION_SHA256SUM" | sha256sum --check || { echo "Failed sha256sum verification on extracted binary..." && exit 1; }
 
 
-echo "###Generating neuter+deactivate+maximize reduction of ME on $bioscopy, outputting minimized ME under $BLOBDIR/me.bin... "
-python3 "$BLOBDIR/me7_update_parser.py" -O "$BLOBDIR/me.bin" app/ME7_5M_UPD_Production.bin || { echo "Failed to generate ME binary..." && exit 1; }
+echo "###Generating neuter+deactivate+maximize reduction of ME on app/ME7_5M_UPD_Production.bin, outputting minimized ME under $BLOBDIR/me.bin... "
+( python3 "$BLOBDIR/me7_update_parser.py" -O "$BLOBDIR/me.bin" app/ME7_5M_UPD_Production.bin ) || { echo "Failed to generate ME binary..." && exit 1; }
 
 echo "### Verifying expected hash of me.bin"
 echo "$FINAL_ME_BIN_SHA256SUM" | sha256sum --check || { echo "Failed sha256sum verification on final binary..." && exit 1; }
 
 
 echo "###Cleaning up..."
-cd -
+cd - || exit 1
 rm -r "$extractdir"

--- a/blobs/xx30/download_clean_me.sh
+++ b/blobs/xx30/download_clean_me.sh
@@ -6,47 +6,54 @@ function printusage {
 
 ME_BIN_HASH="c140d04d792bed555e616065d48bdc327bb78f0213ccc54c0ae95f12b28896a4"
 
+if [ -e "${output_dir}/me.bin" ]; then
+  echo "me.bin already exists"
+  if echo "${ME_BIN_HASH} ${output_dir}/me.bin" | sha256sum --check; then
+    echo "SKIPPING: SHA256 checksum for me.bin matches."
+    exit 0
+  fi
+  echo "me.bin exists but checksum doesn't match. Continuing..."
+fi
+
 if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
-    if [[ "${1:-}" == "--help" ]]; then
-        usage
-    else
-        if [[ -z "${COREBOOT_DIR}" ]]; then
-            echo "ERROR: No COREBOOT_DIR variable defined."
-            exit 1
-      fi
-
-        output_dir="$(realpath "${1:-./}")"
-
-        if [[ ! -f "${output_dir}/me.bin" ]]; then
-            # Unpack Lenovo's Windows installer into a temporary directory and
-            # extract the Intel ME blob.
-            pushd "$(mktemp -d)"
-
-            curl -O https://download.lenovo.com/pccbbs/mobiles/g1rg24ww.exe
-            innoextract g1rg24ww.exe
-
-            mv app/ME8_5M_Production.bin "${COREBOOT_DIR}/util/me_cleaner"
-
-            popd
-
-            # Neutralize and shrink Intel ME. Note that this doesn't include
-            # --soft-disable to set the "ME Disable" or "ME Disable B" (e.g.,
-            # High Assurance Program) bits, as they are defined within the Flash
-            # Descriptor.
-            # https://github.com/corna/me_cleaner/wiki/External-flashing#neutralize-and-shrink-intel-me-useful-only-for-coreboot
-            pushd "${COREBOOT_DIR}/util/me_cleaner"
-
-            python me_cleaner.py -r -t -O me_shrinked.bin ME8_5M_Production.bin
-
-            mv me_shrinked.bin "${output_dir}/me.bin"
-            #rm ./*.bin
-
-            popd
-        fi
-
-        if ! echo "${ME_BIN_HASH} ${output_dir}/me.bin" | sha256sum --check; then
-            echo "ERROR: SHA256 checksum for me.bin doesn't match."
-            exit 1
-        fi
+  if [[ "${1:-}" == "--help" ]]; then
+    usage
+  else
+    if [[ -z "${COREBOOT_DIR}" ]]; then
+      echo "ERROR: No COREBOOT_DIR variable defined."
+      exit 1
     fi
+
+    output_dir="$(realpath "${1:-./}")"
+
+    if [[ ! -f "${output_dir}/me.bin" ]]; then
+      # Unpack Lenovo's Windows installer into a temporary directory and
+      # extract the Intel ME blob.
+      pushd "$(mktemp -d)" || exit
+
+      curl -O https://download.lenovo.com/pccbbs/mobiles/g1rg24ww.exe
+      innoextract g1rg24ww.exe
+
+      mv app/ME8_5M_Production.bin "${COREBOOT_DIR}/util/me_cleaner"
+      rm -rf ./*
+      popd || exit
+
+      # Neutralize and shrink Intel ME. Note that this doesn't include
+      # --soft-disable to set the "ME Disable" or "ME Disable B" (e.g.,
+      # High Assurance Program) bits, as they are defined within the Flash
+      # Descriptor.
+      # https://github.com/corna/me_cleaner/wiki/External-flashing#neutralize-and-shrink-intel-me-useful-only-for-coreboot
+      pushd "${COREBOOT_DIR}/util/me_cleaner" || exit
+
+      python me_cleaner.py -r -t -O me_shrinked.bin ME8_5M_Production.bin
+      rm -f ME8_5M_Production.bin
+      mv me_shrinked.bin "${output_dir}/me.bin"
+      popd || exit
+    fi
+
+    if ! echo "${ME_BIN_HASH} ${output_dir}/me.bin" | sha256sum --check; then
+      echo "ERROR: SHA256 checksum for me.bin doesn't match."
+      exit 1
+    fi
+  fi
 fi

--- a/blobs/xx30/download_clean_me_manually.sh
+++ b/blobs/xx30/download_clean_me_manually.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+function printusage {
+  echo "Usage: $0 -m <me_cleaner>(optional)"
+}
+
+BLOBDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+if [ "$#" -eq 0 ]; then printusage; fi
+
+while getopts ":m:" opt; do
+  case $opt in
+    m)
+      if [ -x "$OPTARG" ]; then
+        MECLEAN="$OPTARG"
+      fi
+      ;;
+  esac
+done
+
+FINAL_ME_BIN_SHA256SUM="c140d04d792bed555e616065d48bdc327bb78f0213ccc54c0ae95f12b28896a4  $BLOBDIR/me.bin"
+ME_EXE_SHA256SUM="f60e1990e2da2b7efa58a645502d22d50afd97b53a092781beee9b0322b61153  g1rg24ww.exe"
+ME8_5M_PRODUCTION_SHA256SUM="821c6fa16e62e15bc902ce2e958ffb61f63349a471685bed0dc78ce721a01bfa  app/ME8_5M_Production.bin"
+
+
+if [ -z "$MECLEAN" ]; then
+  MECLEAN=`command -v $BLOBDIR/../../build/x86/coreboot-*/util/me_cleaner/me_cleaner.py 2>&1|head -n1`
+  if [ -z "$MECLEAN" ]; then
+    echo "me_cleaner.py required but not found or specified with -m. Aborting."
+    exit 1;
+  fi
+fi
+
+echo "### Creating temp dir"
+extractdir=$(mktemp -d)
+cd "$extractdir"
+
+echo "### Downloading https://download.lenovo.com/pccbbs/mobiles/g1rg24ww.exe..."
+wget  https://download.lenovo.com/pccbbs/mobiles/g1rg24ww.exe || { echo "ERROR: wget not found" && exit 1; }
+echo "### Verifying expected hash of g1rg24ww.exe"
+echo "$ME_EXE_SHA256SUM" | sha256sum --check || { echo "Failed sha256sum verification on downloaded binary..." && exit 1; }
+
+echo "### Extracting g1rg24ww.exe..."
+innoextract ./g1rg24ww.exe || { echo "Failed calling innoextract. Tool installed on host?" && exit 1;}
+echo "### Verifying expected hash of app/ME8_5M_Production.bin"
+echo "$ME8_5M_PRODUCTION_SHA256SUM" | sha256sum --check || { echo "Failed sha256sum verification on extracted binary..." && exit 1; }
+
+echo "###Applying me_cleaner to neuter+deactivate+maximize reduction of ME on $bioscopy, outputting minimized ME under $BLOBDIR/me.bin... "
+$MECLEAN -r -t -O "$BLOBDIR/me.bin" app/ME8_5M_Production.bin
+echo "### Verifying expected hash of me.bin"
+echo "$FINAL_ME_BIN_SHA256SUM" | sha256sum --check || { echo "Failed sha256sum verification on final binary..." && exit 1; }
+
+
+echo "###Cleaning up..."
+cd - 
+rm -r "$extractdir"

--- a/blobs/xx30/download_clean_me_manually.sh
+++ b/blobs/xx30/download_clean_me_manually.sh
@@ -4,53 +4,66 @@ function printusage {
   echo "Usage: $0 -m <me_cleaner>(optional)"
 }
 
-BLOBDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+BLOBDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FINAL_ME_BIN_SHA256SUM="c140d04d792bed555e616065d48bdc327bb78f0213ccc54c0ae95f12b28896a4  $BLOBDIR/me.bin"
+ME_EXE_SHA256SUM="f60e1990e2da2b7efa58a645502d22d50afd97b53a092781beee9b0322b61153  g1rg24ww.exe"
+ME8_5M_PRODUCTION_SHA256SUM="821c6fa16e62e15bc902ce2e958ffb61f63349a471685bed0dc78ce721a01bfa  app/ME8_5M_Production.bin"
 
 if [ "$#" -eq 0 ]; then printusage; fi
 
 while getopts ":m:" opt; do
   case $opt in
-    m)
-      if [ -x "$OPTARG" ]; then
-        MECLEAN="$OPTARG"
-      fi
-      ;;
+  m)
+    if [ -x "$OPTARG" ]; then
+      MECLEAN="$OPTARG"
+    fi
+    ;;
+  *)
+    ;;
   esac
 done
 
-FINAL_ME_BIN_SHA256SUM="c140d04d792bed555e616065d48bdc327bb78f0213ccc54c0ae95f12b28896a4  $BLOBDIR/me.bin"
-ME_EXE_SHA256SUM="f60e1990e2da2b7efa58a645502d22d50afd97b53a092781beee9b0322b61153  g1rg24ww.exe"
-ME8_5M_PRODUCTION_SHA256SUM="821c6fa16e62e15bc902ce2e958ffb61f63349a471685bed0dc78ce721a01bfa  app/ME8_5M_Production.bin"
-
+if [ -e "$BLOBDIR/me.bin" ]; then
+  echo "$BLOBDIR/me.bin found..."
+  if ! echo "$FINAL_ME_BIN_SHA256SUM" | sha256sum --check; then
+    echo "$BLOBDIR/me.bin doesn't pass integrity validation. Continuing..."
+    rm -f "$BLOBDIR/me.bin"
+  else
+    echo "$BLOBDIR/me.bin already extracted and neutered outside of ROMP and BUP"
+    exit 0
+  fi
+fi
 
 if [ -z "$MECLEAN" ]; then
-  MECLEAN=`command -v $BLOBDIR/../../build/x86/coreboot-*/util/me_cleaner/me_cleaner.py 2>&1|head -n1`
+  MECLEAN=$(command -v "$BLOBDIR/../../build/x86/coreboot-"*/util/me_cleaner/me_cleaner.py 2>&1 | head -n1)
   if [ -z "$MECLEAN" ]; then
     echo "me_cleaner.py required but not found or specified with -m. Aborting."
-    exit 1;
+    exit 1
   fi
 fi
 
 echo "### Creating temp dir"
 extractdir=$(mktemp -d)
-cd "$extractdir"
+cd "$extractdir" || exit
 
 echo "### Downloading https://download.lenovo.com/pccbbs/mobiles/g1rg24ww.exe..."
-wget  https://download.lenovo.com/pccbbs/mobiles/g1rg24ww.exe || { echo "ERROR: wget not found" && exit 1; }
+wget https://download.lenovo.com/pccbbs/mobiles/g1rg24ww.exe || { echo "ERROR: wget not found" && exit 1; }
 echo "### Verifying expected hash of g1rg24ww.exe"
 echo "$ME_EXE_SHA256SUM" | sha256sum --check || { echo "Failed sha256sum verification on downloaded binary..." && exit 1; }
 
 echo "### Extracting g1rg24ww.exe..."
-innoextract ./g1rg24ww.exe || { echo "Failed calling innoextract. Tool installed on host?" && exit 1;}
+innoextract ./g1rg24ww.exe || { echo "Failed calling innoextract. Tool installed on host?" && exit 1; }
 echo "### Verifying expected hash of app/ME8_5M_Production.bin"
 echo "$ME8_5M_PRODUCTION_SHA256SUM" | sha256sum --check || { echo "Failed sha256sum verification on extracted binary..." && exit 1; }
 
-echo "###Applying me_cleaner to neuter+deactivate+maximize reduction of ME on $bioscopy, outputting minimized ME under $BLOBDIR/me.bin... "
-$MECLEAN -r -t -O "$BLOBDIR/me.bin" app/ME8_5M_Production.bin
+bioscopy="some_value" # Assign a value to the bioscopy variable
+
+echo "### Applying me_cleaner to neuter+deactivate+maximize reduction of ME on $bioscopy, outputting minimized ME under $BLOBDIR/me.bin... "
+"$MECLEAN" -r -t -O "$BLOBDIR/me.bin" app/ME8_5M_Production.bin
 echo "### Verifying expected hash of me.bin"
 echo "$FINAL_ME_BIN_SHA256SUM" | sha256sum --check || { echo "Failed sha256sum verification on final binary..." && exit 1; }
 
+echo "### Cleaning up..."
+cd - >/dev/null
 
-echo "###Cleaning up..."
-cd - 
 rm -r "$extractdir"

--- a/boards/UNTESTED_t520-hotp-maximized/UNTESTED_t520-hotp-maximized.config
+++ b/boards/UNTESTED_t520-hotp-maximized/UNTESTED_t520-hotp-maximized.config
@@ -63,15 +63,5 @@ export CONFIG_BOOT_DEV="/dev/sda1"
 export CONFIG_BOARD_NAME="ThinkPad T520-hotp-maximized"
 export CONFIG_FLASHROM_OPTIONS="--force --noverify-all -p internal:ich_spi_mode=hwseq"
 
-# xx20 boards require of you initially call one of the following to habe gbe.bin ifd.bin and me.bin
-#  - blobs/xx20/download_parse_me.sh
-#     To download Lenovo update ME binary, neuter+deactivate ME, produce reduced IFD ME region and expended BIOS IFD region.
-
-# Make the Coreboot build depend on the following 3rd party blobs:
-$(build)/coreboot-$(CONFIG_COREBOOT_VERSION)/$(BOARD)/.build: \
-    $(pwd)/blobs/xx20/me.bin
-
-
-$(pwd)/blobs/xx20/me.bin:
-	COREBOOT_DIR="$(build)/$(coreboot_base_dir)" \
-		$(pwd)/blobs/xx20/download_parse_me.sh
+#Include bits related to sandybridge ME blob download/neutering down to BUP
+BOARD_TARGETS := xx20_me_blobs

--- a/boards/UNTESTED_t520-hotp-maximized/UNTESTED_t520-hotp-maximized.config
+++ b/boards/UNTESTED_t520-hotp-maximized/UNTESTED_t520-hotp-maximized.config
@@ -29,7 +29,6 @@ CONFIG_PCIUTILS=y
 CONFIG_IO386=y
 export CONFIG_FINALIZE_PLATFORM_LOCKING_PRESKYLAKE=y
 
-
 #Remote attestation support
 #TPM based requirements
 export CONFIG_TPM=y
@@ -67,3 +66,12 @@ export CONFIG_FLASHROM_OPTIONS="--force --noverify-all -p internal:ich_spi_mode=
 # xx20 boards require of you initially call one of the following to habe gbe.bin ifd.bin and me.bin
 #  - blobs/xx20/download_parse_me.sh
 #     To download Lenovo update ME binary, neuter+deactivate ME, produce reduced IFD ME region and expended BIOS IFD region.
+
+# Make the Coreboot build depend on the following 3rd party blobs:
+$(build)/coreboot-$(CONFIG_COREBOOT_VERSION)/$(BOARD)/.build: \
+    $(pwd)/blobs/xx20/me.bin
+
+
+$(pwd)/blobs/xx20/me.bin:
+	COREBOOT_DIR="$(build)/$(coreboot_base_dir)" \
+		$(pwd)/blobs/xx20/download_parse_me.sh

--- a/boards/UNTESTED_t520-maximized/UNTESTED_t520-maximized.config
+++ b/boards/UNTESTED_t520-maximized/UNTESTED_t520-maximized.config
@@ -63,15 +63,5 @@ export CONFIG_BOOT_DEV="/dev/sda1"
 export CONFIG_BOARD_NAME="ThinkPad T520-maximized"
 export CONFIG_FLASHROM_OPTIONS="--force --noverify-all -p internal:ich_spi_mode=hwseq"
 
-# xx20 boards require of you initially call one of the following to habe gbe.bin ifd.bin and me.bin
-#  - blobs/xx20/download_parse_me.sh
-#     To download Lenovo update ME binary, neuter+deactivate ME, produce reduced IFD ME region and expended BIOS IFD region.
-
-# Make the Coreboot build depend on the following 3rd party blobs:
-$(build)/coreboot-$(CONFIG_COREBOOT_VERSION)/$(BOARD)/.build: \
-    $(pwd)/blobs/xx20/me.bin
-
-
-$(pwd)/blobs/xx20/me.bin:
-	COREBOOT_DIR="$(build)/$(coreboot_base_dir)" \
-		$(pwd)/blobs/xx20/download_parse_me.sh
+#Include bits related to sandybridge ME blob download/neutering down to BUP
+BOARD_TARGETS := xx20_me_blobs

--- a/boards/UNTESTED_t520-maximized/UNTESTED_t520-maximized.config
+++ b/boards/UNTESTED_t520-maximized/UNTESTED_t520-maximized.config
@@ -29,7 +29,6 @@ CONFIG_PCIUTILS=y
 CONFIG_IO386=y
 export CONFIG_FINALIZE_PLATFORM_LOCKING_PRESKYLAKE=y
 
-
 #Remote attestation support
 #TPM based requirements
 export CONFIG_TPM=y
@@ -67,3 +66,12 @@ export CONFIG_FLASHROM_OPTIONS="--force --noverify-all -p internal:ich_spi_mode=
 # xx20 boards require of you initially call one of the following to habe gbe.bin ifd.bin and me.bin
 #  - blobs/xx20/download_parse_me.sh
 #     To download Lenovo update ME binary, neuter+deactivate ME, produce reduced IFD ME region and expended BIOS IFD region.
+
+# Make the Coreboot build depend on the following 3rd party blobs:
+$(build)/coreboot-$(CONFIG_COREBOOT_VERSION)/$(BOARD)/.build: \
+    $(pwd)/blobs/xx20/me.bin
+
+
+$(pwd)/blobs/xx20/me.bin:
+	COREBOOT_DIR="$(build)/$(coreboot_base_dir)" \
+		$(pwd)/blobs/xx20/download_parse_me.sh

--- a/boards/UNTESTED_t530-dgpu-hotp-maximized/UNTESTED_t530-dgpu-hotp-maximized.config
+++ b/boards/UNTESTED_t530-dgpu-hotp-maximized/UNTESTED_t530-dgpu-hotp-maximized.config
@@ -75,5 +75,14 @@ export CONFIG_FLASHROM_OPTIONS="--force --noverify-all -p internal"
 #  - blobs/xx30/extract.sh
 #     To extract from backuped 8M (bottom SPI) ME binary, GBE and IFD blobs.
 
+# Make the Coreboot build depend on the following 3rd party blobs:
+$(build)/coreboot-$(CONFIG_COREBOOT_VERSION)/$(BOARD)/.build: \
+    $(pwd)/blobs/xx30/me.bin
+
+
+$(pwd)/blobs/xx30/me.bin:
+	COREBOOT_DIR="$(build)/$(coreboot_base_dir)" \
+		$(pwd)/blobs/xx30/download_clean_me.sh $(pwd)/blobs/xx30
+
 # Generate split 4MB top / 8MB bottom ROMs
 BOARD_TARGETS := split_8mb4mb

--- a/boards/UNTESTED_t530-dgpu-hotp-maximized/UNTESTED_t530-dgpu-hotp-maximized.config
+++ b/boards/UNTESTED_t530-dgpu-hotp-maximized/UNTESTED_t530-dgpu-hotp-maximized.config
@@ -77,12 +77,14 @@ export CONFIG_FLASHROM_OPTIONS="--force --noverify-all -p internal"
 
 # Make the Coreboot build depend on the following 3rd party blobs:
 $(build)/coreboot-$(CONFIG_COREBOOT_VERSION)/$(BOARD)/.build: \
-    $(pwd)/blobs/xx30/me.bin
-
+    $(pwd)/blobs/xx30/me.bin $(pwd)/blobs/xx30/10de,0def.rom $(pwd)/blobs/xx30/8086,0106.rom
 
 $(pwd)/blobs/xx30/me.bin:
 	COREBOOT_DIR="$(build)/$(coreboot_base_dir)" \
 		$(pwd)/blobs/xx30/download_clean_me.sh $(pwd)/blobs/xx30
+
+$(pwd)/blobs/xx30/10de,0def.rom:
+	$(pwd)/blobs/xx30/vbios_t530.sh
 
 # Generate split 4MB top / 8MB bottom ROMs
 BOARD_TARGETS := split_8mb4mb

--- a/boards/UNTESTED_t530-dgpu-hotp-maximized/UNTESTED_t530-dgpu-hotp-maximized.config
+++ b/boards/UNTESTED_t530-dgpu-hotp-maximized/UNTESTED_t530-dgpu-hotp-maximized.config
@@ -67,24 +67,15 @@ export CONFIG_BOOT_DEV="/dev/sda1"
 export CONFIG_BOARD_NAME="Thinkpad T530-dgpu-hotp-maximized"
 export CONFIG_FLASHROM_OPTIONS="--force --noverify-all -p internal"
 
-# xx30-*-maximized boards require of you initially call one of the
-#  following to have gbe.bin ifd.bin and me.bin
-#  - blobs/xx30/download_clean_me.sh
-#     To download Lenovo original ME binary, neuter+deactivate ME, produce
-#      reduced IFD ME region and expanded BIOS IFD region.
-#  - blobs/xx30/extract.sh
-#     To extract from backuped 8M (bottom SPI) ME binary, GBE and IFD blobs.
-
 # Make the Coreboot build depend on the following 3rd party blobs:
 $(build)/coreboot-$(CONFIG_COREBOOT_VERSION)/$(BOARD)/.build: \
     $(pwd)/blobs/xx30/me.bin $(pwd)/blobs/xx30/10de,0def.rom $(pwd)/blobs/xx30/8086,0106.rom
 
-$(pwd)/blobs/xx30/me.bin:
-	COREBOOT_DIR="$(build)/$(coreboot_base_dir)" \
-		$(pwd)/blobs/xx30/download_clean_me.sh $(pwd)/blobs/xx30
+#Include bits related to ivybridge ME blob download/neutering down to BUP+ROMP
+BOARD_TARGETS := xx30_me_blobs
 
 $(pwd)/blobs/xx30/10de,0def.rom:
 	$(pwd)/blobs/xx30/vbios_t530.sh
 
 # Generate split 4MB top / 8MB bottom ROMs
-BOARD_TARGETS := split_8mb4mb
+BOARD_TARGETS += split_8mb4mb

--- a/boards/UNTESTED_t530-dgpu-maximized/UNTESTED_t530-dgpu-maximized.config
+++ b/boards/UNTESTED_t530-dgpu-maximized/UNTESTED_t530-dgpu-maximized.config
@@ -67,25 +67,15 @@ export CONFIG_BOOT_DEV="/dev/sda1"
 export CONFIG_BOARD_NAME="Thinkpad T530-dgpu-maximized"
 export CONFIG_FLASHROM_OPTIONS="--force --noverify-all -p internal"
 
-# xx30-*-maximized boards require of you initially call one of the
-#  following to have gbe.bin ifd.bin and me.bin
-#  - blobs/xx30/download_clean_me.sh
-#     To download Lenovo original ME binary, neuter+deactivate ME, produce
-#      reduced IFD ME region and expanded BIOS IFD region.
-#  - blobs/xx30/extract.sh
-#     To extract from backuped 8M (bottom SPI) ME binary, GBE and IFD blobs.
-
 # Make the Coreboot build depend on the following 3rd party blobs:
 $(build)/coreboot-$(CONFIG_COREBOOT_VERSION)/$(BOARD)/.build: \
     $(pwd)/blobs/xx30/me.bin $(pwd)/blobs/xx30/10de,0def.rom $(pwd)/blobs/xx30/8086,0106.rom
 
-
-$(pwd)/blobs/xx30/me.bin:
-	COREBOOT_DIR="$(build)/$(coreboot_base_dir)" \
-		$(pwd)/blobs/xx30/download_clean_me.sh $(pwd)/blobs/xx30
+#Include bits related to ivybridge ME blob download/neutering down to BUP+ROMP
+BOARD_TARGETS := xx30_me_blobs
 
 $(pwd)/blobs/xx30/10de,0def.rom:
 	$(pwd)/blobs/xx30/vbios_t530.sh
 
 # Generate split 4MB top / 8MB bottom ROMs
-BOARD_TARGETS := split_8mb4mb
+BOARD_TARGETS += split_8mb4mb

--- a/boards/UNTESTED_t530-dgpu-maximized/UNTESTED_t530-dgpu-maximized.config
+++ b/boards/UNTESTED_t530-dgpu-maximized/UNTESTED_t530-dgpu-maximized.config
@@ -75,5 +75,14 @@ export CONFIG_FLASHROM_OPTIONS="--force --noverify-all -p internal"
 #  - blobs/xx30/extract.sh
 #     To extract from backuped 8M (bottom SPI) ME binary, GBE and IFD blobs.
 
+# Make the Coreboot build depend on the following 3rd party blobs:
+$(build)/coreboot-$(CONFIG_COREBOOT_VERSION)/$(BOARD)/.build: \
+    $(pwd)/blobs/xx30/me.bin
+
+
+$(pwd)/blobs/xx30/me.bin:
+	COREBOOT_DIR="$(build)/$(coreboot_base_dir)" \
+		$(pwd)/blobs/xx30/download_clean_me.sh $(pwd)/blobs/xx30
+
 # Generate split 4MB top / 8MB bottom ROMs
 BOARD_TARGETS := split_8mb4mb

--- a/boards/UNTESTED_t530-dgpu-maximized/UNTESTED_t530-dgpu-maximized.config
+++ b/boards/UNTESTED_t530-dgpu-maximized/UNTESTED_t530-dgpu-maximized.config
@@ -77,12 +77,15 @@ export CONFIG_FLASHROM_OPTIONS="--force --noverify-all -p internal"
 
 # Make the Coreboot build depend on the following 3rd party blobs:
 $(build)/coreboot-$(CONFIG_COREBOOT_VERSION)/$(BOARD)/.build: \
-    $(pwd)/blobs/xx30/me.bin
+    $(pwd)/blobs/xx30/me.bin $(pwd)/blobs/xx30/10de,0def.rom $(pwd)/blobs/xx30/8086,0106.rom
 
 
 $(pwd)/blobs/xx30/me.bin:
 	COREBOOT_DIR="$(build)/$(coreboot_base_dir)" \
 		$(pwd)/blobs/xx30/download_clean_me.sh $(pwd)/blobs/xx30
+
+$(pwd)/blobs/xx30/10de,0def.rom:
+	$(pwd)/blobs/xx30/vbios_t530.sh
 
 # Generate split 4MB top / 8MB bottom ROMs
 BOARD_TARGETS := split_8mb4mb

--- a/boards/UNTESTED_t530-hotp-maximized/UNTESTED_t530-hotp-maximized.config
+++ b/boards/UNTESTED_t530-hotp-maximized/UNTESTED_t530-hotp-maximized.config
@@ -75,5 +75,14 @@ export CONFIG_FLASHROM_OPTIONS="--force --noverify-all -p internal"
 #  - blobs/xx30/extract.sh
 #     To extract from backuped 8M (bottom SPI) ME binary, GBE and IFD blobs.
 
+# Make the Coreboot build depend on the following 3rd party blobs:
+$(build)/coreboot-$(CONFIG_COREBOOT_VERSION)/$(BOARD)/.build: \
+    $(pwd)/blobs/xx30/me.bin
+
+
+$(pwd)/blobs/xx30/me.bin:
+	COREBOOT_DIR="$(build)/$(coreboot_base_dir)" \
+		$(pwd)/blobs/xx30/download_clean_me.sh $(pwd)/blobs/xx30
+
 # Generate split 4MB top / 8MB bottom ROMs
 BOARD_TARGETS := split_8mb4mb

--- a/boards/UNTESTED_t530-hotp-maximized/UNTESTED_t530-hotp-maximized.config
+++ b/boards/UNTESTED_t530-hotp-maximized/UNTESTED_t530-hotp-maximized.config
@@ -67,22 +67,8 @@ export CONFIG_BOOT_DEV="/dev/sda1"
 export CONFIG_BOARD_NAME="Thinkpad T530-hotp-maximized"
 export CONFIG_FLASHROM_OPTIONS="--force --noverify-all -p internal"
 
-# xx30-*-maximized boards require of you initially call one of the
-#  following to have gbe.bin ifd.bin and me.bin
-#  - blobs/xx30/download_clean_me.sh
-#     To download Lenovo original ME binary, neuter+deactivate ME, produce
-#      reduced IFD ME region and expanded BIOS IFD region.
-#  - blobs/xx30/extract.sh
-#     To extract from backuped 8M (bottom SPI) ME binary, GBE and IFD blobs.
-
-# Make the Coreboot build depend on the following 3rd party blobs:
-$(build)/coreboot-$(CONFIG_COREBOOT_VERSION)/$(BOARD)/.build: \
-    $(pwd)/blobs/xx30/me.bin
-
-
-$(pwd)/blobs/xx30/me.bin:
-	COREBOOT_DIR="$(build)/$(coreboot_base_dir)" \
-		$(pwd)/blobs/xx30/download_clean_me.sh $(pwd)/blobs/xx30
+#Include bits related to ivybridge ME blob download/neutering down to BUP+ROMP
+BOARD_TARGETS := xx30_me_blobs
 
 # Generate split 4MB top / 8MB bottom ROMs
-BOARD_TARGETS := split_8mb4mb
+BOARD_TARGETS += split_8mb4mb

--- a/boards/UNTESTED_t530-maximized/UNTESTED_t530-maximized.config
+++ b/boards/UNTESTED_t530-maximized/UNTESTED_t530-maximized.config
@@ -75,5 +75,14 @@ export CONFIG_FLASHROM_OPTIONS="--force --noverify-all -p internal"
 #  - blobs/xx30/extract.sh
 #     To extract from backuped 8M (bottom SPI) ME binary, GBE and IFD blobs.
 
+# Make the Coreboot build depend on the following 3rd party blobs:
+$(build)/coreboot-$(CONFIG_COREBOOT_VERSION)/$(BOARD)/.build: \
+    $(pwd)/blobs/xx30/me.bin
+
+
+$(pwd)/blobs/xx30/me.bin:
+	COREBOOT_DIR="$(build)/$(coreboot_base_dir)" \
+		$(pwd)/blobs/xx30/download_clean_me.sh $(pwd)/blobs/xx30
+
 # Generate split 4MB top / 8MB bottom ROMs
 BOARD_TARGETS := split_8mb4mb

--- a/boards/UNTESTED_t530-maximized/UNTESTED_t530-maximized.config
+++ b/boards/UNTESTED_t530-maximized/UNTESTED_t530-maximized.config
@@ -67,22 +67,8 @@ export CONFIG_BOOT_DEV="/dev/sda1"
 export CONFIG_BOARD_NAME="Thinkpad T530-maximized"
 export CONFIG_FLASHROM_OPTIONS="--force --noverify-all -p internal"
 
-# xx30-*-maximized boards require of you initially call one of the
-#  following to have gbe.bin ifd.bin and me.bin
-#  - blobs/xx30/download_clean_me.sh
-#     To download Lenovo original ME binary, neuter+deactivate ME, produce
-#      reduced IFD ME region and expanded BIOS IFD region.
-#  - blobs/xx30/extract.sh
-#     To extract from backuped 8M (bottom SPI) ME binary, GBE and IFD blobs.
-
-# Make the Coreboot build depend on the following 3rd party blobs:
-$(build)/coreboot-$(CONFIG_COREBOOT_VERSION)/$(BOARD)/.build: \
-    $(pwd)/blobs/xx30/me.bin
-
-
-$(pwd)/blobs/xx30/me.bin:
-	COREBOOT_DIR="$(build)/$(coreboot_base_dir)" \
-		$(pwd)/blobs/xx30/download_clean_me.sh $(pwd)/blobs/xx30
+#Include bits related to ivybridge ME blob download/neutering down to BUP+ROMP
+BOARD_TARGETS := xx30_me_blobs
 
 # Generate split 4MB top / 8MB bottom ROMs
-BOARD_TARGETS := split_8mb4mb
+BOARD_TARGETS += split_8mb4mb

--- a/boards/UNTESTED_w530-dgpu-K1000m-hotp-maximized/UNTESTED_w530-dgpu-K1000m-hotp-maximized.config
+++ b/boards/UNTESTED_w530-dgpu-K1000m-hotp-maximized/UNTESTED_w530-dgpu-K1000m-hotp-maximized.config
@@ -75,5 +75,14 @@ export CONFIG_FLASHROM_OPTIONS="--force --noverify-all -p internal"
 #  - blobs/xx30/extract.sh
 #     To extract from backuped 8M (bottom SPI) ME binary, GBE and IFD blobs.
 
+# Make the Coreboot build depend on the following 3rd party blobs:
+$(build)/coreboot-$(CONFIG_COREBOOT_VERSION)/$(BOARD)/.build: \
+    $(pwd)/blobs/xx30/me.bin
+
+
+$(pwd)/blobs/xx30/me.bin:
+	COREBOOT_DIR="$(build)/$(coreboot_base_dir)" \
+		$(pwd)/blobs/xx30/download_clean_me.sh $(pwd)/blobs/xx30
+
 # Generate split 4MB top / 8MB bottom ROMs
 BOARD_TARGETS := split_8mb4mb

--- a/boards/UNTESTED_w530-dgpu-K1000m-hotp-maximized/UNTESTED_w530-dgpu-K1000m-hotp-maximized.config
+++ b/boards/UNTESTED_w530-dgpu-K1000m-hotp-maximized/UNTESTED_w530-dgpu-K1000m-hotp-maximized.config
@@ -79,13 +79,11 @@ export CONFIG_FLASHROM_OPTIONS="--force --noverify-all -p internal"
 $(build)/coreboot-$(CONFIG_COREBOOT_VERSION)/$(BOARD)/.build: \
     $(pwd)/blobs/xx30/me.bin $(pwd)/blobs/xx30/10de,0ffc.rom $(pwd)/blobs/xx30/8086,0106.rom
 
-
-$(pwd)/blobs/xx30/me.bin:
-	COREBOOT_DIR="$(build)/$(coreboot_base_dir)" \
-		$(pwd)/blobs/xx30/download_clean_me.sh $(pwd)/blobs/xx30
+#Include bits related to ivybridge ME blob download/neutering down to BUP+ROMP
+BOARD_TARGETS := xx30_me_blobs
 
 $(pwd)/blobs/xx30/10de,0ffc.rom:
 	$(pwd)/blobs/xx30/vbios_w530.sh
 
 # Generate split 4MB top / 8MB bottom ROMs
-BOARD_TARGETS := split_8mb4mb
+BOARD_TARGETS += split_8mb4mb

--- a/boards/UNTESTED_w530-dgpu-K1000m-hotp-maximized/UNTESTED_w530-dgpu-K1000m-hotp-maximized.config
+++ b/boards/UNTESTED_w530-dgpu-K1000m-hotp-maximized/UNTESTED_w530-dgpu-K1000m-hotp-maximized.config
@@ -77,12 +77,15 @@ export CONFIG_FLASHROM_OPTIONS="--force --noverify-all -p internal"
 
 # Make the Coreboot build depend on the following 3rd party blobs:
 $(build)/coreboot-$(CONFIG_COREBOOT_VERSION)/$(BOARD)/.build: \
-    $(pwd)/blobs/xx30/me.bin
+    $(pwd)/blobs/xx30/me.bin $(pwd)/blobs/xx30/10de,0ffc.rom $(pwd)/blobs/xx30/8086,0106.rom
 
 
 $(pwd)/blobs/xx30/me.bin:
 	COREBOOT_DIR="$(build)/$(coreboot_base_dir)" \
 		$(pwd)/blobs/xx30/download_clean_me.sh $(pwd)/blobs/xx30
+
+$(pwd)/blobs/xx30/10de,0ffc.rom:
+	$(pwd)/blobs/xx30/vbios_w530.sh
 
 # Generate split 4MB top / 8MB bottom ROMs
 BOARD_TARGETS := split_8mb4mb

--- a/boards/UNTESTED_w530-dgpu-K1000m-maximized/UNTESTED_w530-dgpu-K1000m-maximized.config
+++ b/boards/UNTESTED_w530-dgpu-K1000m-maximized/UNTESTED_w530-dgpu-K1000m-maximized.config
@@ -75,5 +75,14 @@ export CONFIG_FLASHROM_OPTIONS="--force --noverify-all -p internal"
 #  - blobs/xx30/extract.sh
 #     To extract from backuped 8M (bottom SPI) ME binary, GBE and IFD blobs.
 
+# Make the Coreboot build depend on the following 3rd party blobs:
+$(build)/coreboot-$(CONFIG_COREBOOT_VERSION)/$(BOARD)/.build: \
+    $(pwd)/blobs/xx30/me.bin
+
+
+$(pwd)/blobs/xx30/me.bin:
+	COREBOOT_DIR="$(build)/$(coreboot_base_dir)" \
+		$(pwd)/blobs/xx30/download_clean_me.sh $(pwd)/blobs/xx30
+
 # Generate split 4MB top / 8MB bottom ROMs
 BOARD_TARGETS := split_8mb4mb

--- a/boards/UNTESTED_w530-dgpu-K1000m-maximized/UNTESTED_w530-dgpu-K1000m-maximized.config
+++ b/boards/UNTESTED_w530-dgpu-K1000m-maximized/UNTESTED_w530-dgpu-K1000m-maximized.config
@@ -79,13 +79,11 @@ export CONFIG_FLASHROM_OPTIONS="--force --noverify-all -p internal"
 $(build)/coreboot-$(CONFIG_COREBOOT_VERSION)/$(BOARD)/.build: \
     $(pwd)/blobs/xx30/me.bin $(pwd)/blobs/xx30/10de,0ffc.rom $(pwd)/blobs/xx30/8086,0106.rom
 
-
-$(pwd)/blobs/xx30/me.bin:
-	COREBOOT_DIR="$(build)/$(coreboot_base_dir)" \
-		$(pwd)/blobs/xx30/download_clean_me.sh $(pwd)/blobs/xx30
+#Include bits related to ivybridge ME blob download/neutering down to BUP+ROMP
+BOARD_TARGETS := xx30_me_blobs
 
 $(pwd)/blobs/xx30/10de,0ffc.rom:
 	$(pwd)/blobs/xx30/vbios_w530.sh
 
 # Generate split 4MB top / 8MB bottom ROMs
-BOARD_TARGETS := split_8mb4mb
+BOARD_TARGETS += split_8mb4mb

--- a/boards/UNTESTED_w530-dgpu-K1000m-maximized/UNTESTED_w530-dgpu-K1000m-maximized.config
+++ b/boards/UNTESTED_w530-dgpu-K1000m-maximized/UNTESTED_w530-dgpu-K1000m-maximized.config
@@ -77,12 +77,15 @@ export CONFIG_FLASHROM_OPTIONS="--force --noverify-all -p internal"
 
 # Make the Coreboot build depend on the following 3rd party blobs:
 $(build)/coreboot-$(CONFIG_COREBOOT_VERSION)/$(BOARD)/.build: \
-    $(pwd)/blobs/xx30/me.bin
+    $(pwd)/blobs/xx30/me.bin $(pwd)/blobs/xx30/10de,0ffc.rom $(pwd)/blobs/xx30/8086,0106.rom
 
 
 $(pwd)/blobs/xx30/me.bin:
 	COREBOOT_DIR="$(build)/$(coreboot_base_dir)" \
 		$(pwd)/blobs/xx30/download_clean_me.sh $(pwd)/blobs/xx30
+
+$(pwd)/blobs/xx30/10de,0ffc.rom:
+	$(pwd)/blobs/xx30/vbios_w530.sh
 
 # Generate split 4MB top / 8MB bottom ROMs
 BOARD_TARGETS := split_8mb4mb

--- a/boards/UNTESTED_w530-dgpu-K2000m-hotp-maximized/UNTESTED_w530-dgpu-K2000m-hotp-maximized.config
+++ b/boards/UNTESTED_w530-dgpu-K2000m-hotp-maximized/UNTESTED_w530-dgpu-K2000m-hotp-maximized.config
@@ -79,13 +79,11 @@ export CONFIG_FLASHROM_OPTIONS="--force --noverify-all -p internal"
 $(build)/coreboot-$(CONFIG_COREBOOT_VERSION)/$(BOARD)/.build: \
     $(pwd)/blobs/xx30/me.bin $(pwd)/blobs/xx30/10de,0ffb.rom $(pwd)/blobs/xx30/8086,0106.rom
 
-
-$(pwd)/blobs/xx30/me.bin:
-	COREBOOT_DIR="$(build)/$(coreboot_base_dir)" \
-		$(pwd)/blobs/xx30/download_clean_me.sh $(pwd)/blobs/xx30
+#Include bits related to ivybridge ME blob download/neutering down to BUP+ROMP
+BOARD_TARGETS := xx30_me_blobs
 
 $(pwd)/blobs/xx30/10de,0ffb.rom:
 	$(pwd)/blobs/xx30/vbios_w530.sh
 
 # Generate split 4MB top / 8MB bottom ROMs
-BOARD_TARGETS := split_8mb4mb
+BOARD_TARGETS += split_8mb4mb

--- a/boards/UNTESTED_w530-dgpu-K2000m-hotp-maximized/UNTESTED_w530-dgpu-K2000m-hotp-maximized.config
+++ b/boards/UNTESTED_w530-dgpu-K2000m-hotp-maximized/UNTESTED_w530-dgpu-K2000m-hotp-maximized.config
@@ -77,12 +77,15 @@ export CONFIG_FLASHROM_OPTIONS="--force --noverify-all -p internal"
 
 # Make the Coreboot build depend on the following 3rd party blobs:
 $(build)/coreboot-$(CONFIG_COREBOOT_VERSION)/$(BOARD)/.build: \
-    $(pwd)/blobs/xx30/me.bin
+    $(pwd)/blobs/xx30/me.bin $(pwd)/blobs/xx30/10de,0ffb.rom $(pwd)/blobs/xx30/8086,0106.rom
 
 
 $(pwd)/blobs/xx30/me.bin:
 	COREBOOT_DIR="$(build)/$(coreboot_base_dir)" \
 		$(pwd)/blobs/xx30/download_clean_me.sh $(pwd)/blobs/xx30
+
+$(pwd)/blobs/xx30/10de,0ffb.rom:
+	$(pwd)/blobs/xx30/vbios_w530.sh
 
 # Generate split 4MB top / 8MB bottom ROMs
 BOARD_TARGETS := split_8mb4mb

--- a/boards/UNTESTED_w530-dgpu-K2000m-hotp-maximized/UNTESTED_w530-dgpu-K2000m-hotp-maximized.config
+++ b/boards/UNTESTED_w530-dgpu-K2000m-hotp-maximized/UNTESTED_w530-dgpu-K2000m-hotp-maximized.config
@@ -75,5 +75,14 @@ export CONFIG_FLASHROM_OPTIONS="--force --noverify-all -p internal"
 #  - blobs/xx30/extract.sh
 #     To extract from backuped 8M (bottom SPI) ME binary, GBE and IFD blobs.
 
+# Make the Coreboot build depend on the following 3rd party blobs:
+$(build)/coreboot-$(CONFIG_COREBOOT_VERSION)/$(BOARD)/.build: \
+    $(pwd)/blobs/xx30/me.bin
+
+
+$(pwd)/blobs/xx30/me.bin:
+	COREBOOT_DIR="$(build)/$(coreboot_base_dir)" \
+		$(pwd)/blobs/xx30/download_clean_me.sh $(pwd)/blobs/xx30
+
 # Generate split 4MB top / 8MB bottom ROMs
 BOARD_TARGETS := split_8mb4mb

--- a/boards/UNTESTED_w530-dgpu-K2000m-maximized/UNTESTED_w530-dgpu-K2000m-maximized.config
+++ b/boards/UNTESTED_w530-dgpu-K2000m-maximized/UNTESTED_w530-dgpu-K2000m-maximized.config
@@ -79,13 +79,11 @@ export CONFIG_FLASHROM_OPTIONS="--force --noverify-all -p internal"
 $(build)/coreboot-$(CONFIG_COREBOOT_VERSION)/$(BOARD)/.build: \
     $(pwd)/blobs/xx30/me.bin $(pwd)/blobs/xx30/10de,0ffb.rom $(pwd)/blobs/xx30/8086,0106.rom
 
-
-$(pwd)/blobs/xx30/me.bin:
-	COREBOOT_DIR="$(build)/$(coreboot_base_dir)" \
-		$(pwd)/blobs/xx30/download_clean_me.sh $(pwd)/blobs/xx30
+#Include bits related to ivybridge ME blob download/neutering down to BUP+ROMP
+BOARD_TARGETS := xx30_me_blobs
 
 $(pwd)/blobs/xx30/10de,0ffb.rom:
 	$(pwd)/blobs/xx30/vbios_w530.sh
 
 # Generate split 4MB top / 8MB bottom ROMs
-BOARD_TARGETS := split_8mb4mb
+BOARD_TARGETS += split_8mb4mb

--- a/boards/UNTESTED_w530-dgpu-K2000m-maximized/UNTESTED_w530-dgpu-K2000m-maximized.config
+++ b/boards/UNTESTED_w530-dgpu-K2000m-maximized/UNTESTED_w530-dgpu-K2000m-maximized.config
@@ -77,12 +77,15 @@ export CONFIG_FLASHROM_OPTIONS="--force --noverify-all -p internal"
 
 # Make the Coreboot build depend on the following 3rd party blobs:
 $(build)/coreboot-$(CONFIG_COREBOOT_VERSION)/$(BOARD)/.build: \
-    $(pwd)/blobs/xx30/me.bin
+    $(pwd)/blobs/xx30/me.bin $(pwd)/blobs/xx30/10de,0ffb.rom $(pwd)/blobs/xx30/8086,0106.rom
 
 
 $(pwd)/blobs/xx30/me.bin:
 	COREBOOT_DIR="$(build)/$(coreboot_base_dir)" \
 		$(pwd)/blobs/xx30/download_clean_me.sh $(pwd)/blobs/xx30
+
+$(pwd)/blobs/xx30/10de,0ffb.rom:
+	$(pwd)/blobs/xx30/vbios_w530.sh
 
 # Generate split 4MB top / 8MB bottom ROMs
 BOARD_TARGETS := split_8mb4mb

--- a/boards/UNTESTED_w530-dgpu-K2000m-maximized/UNTESTED_w530-dgpu-K2000m-maximized.config
+++ b/boards/UNTESTED_w530-dgpu-K2000m-maximized/UNTESTED_w530-dgpu-K2000m-maximized.config
@@ -75,5 +75,14 @@ export CONFIG_FLASHROM_OPTIONS="--force --noverify-all -p internal"
 #  - blobs/xx30/extract.sh
 #     To extract from backuped 8M (bottom SPI) ME binary, GBE and IFD blobs.
 
+# Make the Coreboot build depend on the following 3rd party blobs:
+$(build)/coreboot-$(CONFIG_COREBOOT_VERSION)/$(BOARD)/.build: \
+    $(pwd)/blobs/xx30/me.bin
+
+
+$(pwd)/blobs/xx30/me.bin:
+	COREBOOT_DIR="$(build)/$(coreboot_base_dir)" \
+		$(pwd)/blobs/xx30/download_clean_me.sh $(pwd)/blobs/xx30
+
 # Generate split 4MB top / 8MB bottom ROMs
 BOARD_TARGETS := split_8mb4mb

--- a/boards/t420-hotp-maximized/t420-hotp-maximized.config
+++ b/boards/t420-hotp-maximized/t420-hotp-maximized.config
@@ -67,15 +67,5 @@ export CONFIG_BOOT_DEV="/dev/sda1"
 export CONFIG_BOARD_NAME="ThinkPad T420-hotp-maximized"
 export CONFIG_FLASHROM_OPTIONS="--force --noverify-all -p internal:ich_spi_mode=hwseq"
 
-# xx20 boards require of you initially call one of the following to habe gbe.bin ifd.bin and me.bin
-#  - blobs/xx20/download_parse_me.sh
-#     To download Lenovo update ME binary, neuter+deactivate ME, produce reduced IFD ME region and expended BIOS IFD region.
-
-# Make the Coreboot build depend on the following 3rd party blobs:
-$(build)/coreboot-$(CONFIG_COREBOOT_VERSION)/$(BOARD)/.build: \
-    $(pwd)/blobs/xx20/me.bin
-
-
-$(pwd)/blobs/xx20/me.bin:
-	COREBOOT_DIR="$(build)/$(coreboot_base_dir)" \
-		$(pwd)/blobs/xx20/download_parse_me.sh
+#Include bits related to sandybridge ME blob download/neutering down to BUP
+BOARD_TARGETS := xx20_me_blobs

--- a/boards/t420-hotp-maximized/t420-hotp-maximized.config
+++ b/boards/t420-hotp-maximized/t420-hotp-maximized.config
@@ -33,7 +33,6 @@ CONFIG_PCIUTILS=y
 CONFIG_IO386=y
 export CONFIG_FINALIZE_PLATFORM_LOCKING_PRESKYLAKE=y
 
-
 #Remote attestation support
 #TPM based requirements
 export CONFIG_TPM=y
@@ -71,3 +70,12 @@ export CONFIG_FLASHROM_OPTIONS="--force --noverify-all -p internal:ich_spi_mode=
 # xx20 boards require of you initially call one of the following to habe gbe.bin ifd.bin and me.bin
 #  - blobs/xx20/download_parse_me.sh
 #     To download Lenovo update ME binary, neuter+deactivate ME, produce reduced IFD ME region and expended BIOS IFD region.
+
+# Make the Coreboot build depend on the following 3rd party blobs:
+$(build)/coreboot-$(CONFIG_COREBOOT_VERSION)/$(BOARD)/.build: \
+    $(pwd)/blobs/xx20/me.bin
+
+
+$(pwd)/blobs/xx20/me.bin:
+	COREBOOT_DIR="$(build)/$(coreboot_base_dir)" \
+		$(pwd)/blobs/xx20/download_parse_me.sh

--- a/boards/t420-maximized/t420-maximized.config
+++ b/boards/t420-maximized/t420-maximized.config
@@ -66,15 +66,5 @@ export CONFIG_BOOT_DEV="/dev/sda1"
 export CONFIG_BOARD_NAME="ThinkPad T420-maximized"
 export CONFIG_FLASHROM_OPTIONS="--force --noverify-all -p internal:ich_spi_mode=hwseq"
 
-# xx20 boards require of you initially call one of the following to habe gbe.bin ifd.bin and me.bin
-#  - blobs/xx20/download_parse_me.sh
-#     To download Lenovo update ME binary, neuter+deactivate ME, produce reduced IFD ME region and expended BIOS IFD region.
-
-# Make the Coreboot build depend on the following 3rd party blobs:
-$(build)/coreboot-$(CONFIG_COREBOOT_VERSION)/$(BOARD)/.build: \
-    $(pwd)/blobs/xx20/me.bin
-
-
-$(pwd)/blobs/xx20/me.bin:
-	COREBOOT_DIR="$(build)/$(coreboot_base_dir)" \
-		$(pwd)/blobs/xx20/download_parse_me.sh
+#Include bits related to sandybridge ME blob download/neutering down to BUP
+BOARD_TARGETS := xx20_me_blobs

--- a/boards/t420-maximized/t420-maximized.config
+++ b/boards/t420-maximized/t420-maximized.config
@@ -69,3 +69,12 @@ export CONFIG_FLASHROM_OPTIONS="--force --noverify-all -p internal:ich_spi_mode=
 # xx20 boards require of you initially call one of the following to habe gbe.bin ifd.bin and me.bin
 #  - blobs/xx20/download_parse_me.sh
 #     To download Lenovo update ME binary, neuter+deactivate ME, produce reduced IFD ME region and expended BIOS IFD region.
+
+# Make the Coreboot build depend on the following 3rd party blobs:
+$(build)/coreboot-$(CONFIG_COREBOOT_VERSION)/$(BOARD)/.build: \
+    $(pwd)/blobs/xx20/me.bin
+
+
+$(pwd)/blobs/xx20/me.bin:
+	COREBOOT_DIR="$(build)/$(coreboot_base_dir)" \
+		$(pwd)/blobs/xx20/download_parse_me.sh

--- a/boards/t430-hotp-maximized/t430-hotp-maximized.config
+++ b/boards/t430-hotp-maximized/t430-hotp-maximized.config
@@ -73,5 +73,14 @@ export CONFIG_FLASHROM_OPTIONS="--force --noverify-all -p internal"
 #  - blobs/xx30/extract.sh
 #     To extract from backuped 8M (bottom SPI) ME binary, GBE and IFD blobs.
 
+# Make the Coreboot build depend on the following 3rd party blobs:
+$(build)/coreboot-$(CONFIG_COREBOOT_VERSION)/$(BOARD)/.build: \
+    $(pwd)/blobs/xx30/me.bin
+
+
+$(pwd)/blobs/xx30/me.bin:
+	COREBOOT_DIR="$(build)/$(coreboot_base_dir)" \
+		$(pwd)/blobs/xx30/download_clean_me.sh $(pwd)/blobs/xx30
+
 # Generate split 4MB top / 8MB bottom ROMs
 BOARD_TARGETS := split_8mb4mb

--- a/boards/t430-hotp-maximized/t430-hotp-maximized.config
+++ b/boards/t430-hotp-maximized/t430-hotp-maximized.config
@@ -65,22 +65,8 @@ export CONFIG_BOOT_DEV="/dev/sda1"
 export CONFIG_BOARD_NAME="Thinkpad T430-hotp-maximized"
 export CONFIG_FLASHROM_OPTIONS="--force --noverify-all -p internal"
 
-# xx30-*-maximized boards require of you initially call one of the
-#  following to have gbe.bin ifd.bin and me.bin
-#  - blobs/xx30/download_clean_me.sh
-#     To download Lenovo original ME binary, neuter+deactivate ME, produce
-#      reduced IFD ME region and expanded BIOS IFD region.
-#  - blobs/xx30/extract.sh
-#     To extract from backuped 8M (bottom SPI) ME binary, GBE and IFD blobs.
-
-# Make the Coreboot build depend on the following 3rd party blobs:
-$(build)/coreboot-$(CONFIG_COREBOOT_VERSION)/$(BOARD)/.build: \
-    $(pwd)/blobs/xx30/me.bin
-
-
-$(pwd)/blobs/xx30/me.bin:
-	COREBOOT_DIR="$(build)/$(coreboot_base_dir)" \
-		$(pwd)/blobs/xx30/download_clean_me.sh $(pwd)/blobs/xx30
+#Include bits related to ivybridge ME blob download/neutering down to BUP+ROMP
+BOARD_TARGETS := xx30_me_blobs
 
 # Generate split 4MB top / 8MB bottom ROMs
-BOARD_TARGETS := split_8mb4mb
+BOARD_TARGETS += split_8mb4mb

--- a/boards/t430-maximized/t430-maximized.config
+++ b/boards/t430-maximized/t430-maximized.config
@@ -74,5 +74,14 @@ export CONFIG_FLASHROM_OPTIONS="--force --noverify-all -p internal"
 #  - blobs/xx30/extract.sh
 #     To extract from backuped 8M (bottom SPI) ME binary, GBE and IFD blobs.
 
+# Make the Coreboot build depend on the following 3rd party blobs:
+$(build)/coreboot-$(CONFIG_COREBOOT_VERSION)/$(BOARD)/.build: \
+    $(pwd)/blobs/xx30/me.bin
+
+
+$(pwd)/blobs/xx30/me.bin:
+	COREBOOT_DIR="$(build)/$(coreboot_base_dir)" \
+		$(pwd)/blobs/xx30/download_clean_me.sh $(pwd)/blobs/xx30
+
 # Generate split 4MB top / 8MB bottom ROMs
 BOARD_TARGETS := split_8mb4mb

--- a/boards/t430-maximized/t430-maximized.config
+++ b/boards/t430-maximized/t430-maximized.config
@@ -66,22 +66,8 @@ export CONFIG_BOOT_DEV="/dev/sda1"
 export CONFIG_BOARD_NAME="Thinkpad T430-maximized"
 export CONFIG_FLASHROM_OPTIONS="--force --noverify-all -p internal"
 
-# xx30-*-maximized boards require of you initially call one of the
-#  following to have gbe.bin ifd.bin and me.bin
-#  - blobs/xx30/download_clean_me.sh
-#     To download Lenovo original ME binary, neuter+deactivate ME, produce
-#      reduced IFD ME region and expanded BIOS IFD region.
-#  - blobs/xx30/extract.sh
-#     To extract from backuped 8M (bottom SPI) ME binary, GBE and IFD blobs.
-
-# Make the Coreboot build depend on the following 3rd party blobs:
-$(build)/coreboot-$(CONFIG_COREBOOT_VERSION)/$(BOARD)/.build: \
-    $(pwd)/blobs/xx30/me.bin
-
-
-$(pwd)/blobs/xx30/me.bin:
-	COREBOOT_DIR="$(build)/$(coreboot_base_dir)" \
-		$(pwd)/blobs/xx30/download_clean_me.sh $(pwd)/blobs/xx30
+#Include bits related to ivybridge ME blob download/neutering down to BUP+ROMP
+BOARD_TARGETS := xx30_me_blobs
 
 # Generate split 4MB top / 8MB bottom ROMs
-BOARD_TARGETS := split_8mb4mb
+BOARD_TARGETS += split_8mb4mb

--- a/boards/t440p-maximized/t440p-maximized.config
+++ b/boards/t440p-maximized/t440p-maximized.config
@@ -53,4 +53,4 @@ $(pwd)/blobs/t440p/me.bin:
 		$(pwd)/blobs/t440p/download-clean-me $(pwd)/blobs/t440p
 
 # Generate split 4MB top / 8MB bottom ROMs
-BOARD_TARGETS := split_8mb4mb
+BOARD_TARGETS += split_8mb4mb

--- a/boards/w530-hotp-maximized/w530-hotp-maximized.config
+++ b/boards/w530-hotp-maximized/w530-hotp-maximized.config
@@ -75,5 +75,14 @@ export CONFIG_FLASHROM_OPTIONS="--force --noverify-all -p internal"
 #  - blobs/xx30/extract.sh
 #     To extract from backuped 8M (bottom SPI) ME binary, GBE and IFD blobs.
 
+# Make the Coreboot build depend on the following 3rd party blobs:
+$(build)/coreboot-$(CONFIG_COREBOOT_VERSION)/$(BOARD)/.build: \
+    $(pwd)/blobs/xx30/me.bin
+
+
+$(pwd)/blobs/xx30/me.bin:
+	COREBOOT_DIR="$(build)/$(coreboot_base_dir)" \
+		$(pwd)/blobs/xx30/download_clean_me.sh $(pwd)/blobs/xx30
+
 # Generate split 4MB top / 8MB bottom ROMs
 BOARD_TARGETS := split_8mb4mb

--- a/boards/w530-hotp-maximized/w530-hotp-maximized.config
+++ b/boards/w530-hotp-maximized/w530-hotp-maximized.config
@@ -67,22 +67,8 @@ export CONFIG_BOOT_DEV="/dev/sda1"
 export CONFIG_BOARD_NAME="Thinkpad W530-hotp-maximized"
 export CONFIG_FLASHROM_OPTIONS="--force --noverify-all -p internal"
 
-# xx30-*-maximized boards require of you initially call one of the
-#  following to have gbe.bin ifd.bin and me.bin
-#  - blobs/xx30/download_clean_me.sh
-#     To download Lenovo original ME binary, neuter+deactivate ME, produce
-#      reduced IFD ME region and expanded BIOS IFD region.
-#  - blobs/xx30/extract.sh
-#     To extract from backuped 8M (bottom SPI) ME binary, GBE and IFD blobs.
-
-# Make the Coreboot build depend on the following 3rd party blobs:
-$(build)/coreboot-$(CONFIG_COREBOOT_VERSION)/$(BOARD)/.build: \
-    $(pwd)/blobs/xx30/me.bin
-
-
-$(pwd)/blobs/xx30/me.bin:
-	COREBOOT_DIR="$(build)/$(coreboot_base_dir)" \
-		$(pwd)/blobs/xx30/download_clean_me.sh $(pwd)/blobs/xx30
+#Include bits related to ivybridge ME blob download/neutering down to BUP+ROMP
+BOARD_TARGETS := xx30_me_blobs
 
 # Generate split 4MB top / 8MB bottom ROMs
-BOARD_TARGETS := split_8mb4mb
+BOARD_TARGETS += split_8mb4mb

--- a/boards/w530-maximized/w530-maximized.config
+++ b/boards/w530-maximized/w530-maximized.config
@@ -75,5 +75,14 @@ export CONFIG_FLASHROM_OPTIONS="--force --noverify-all -p internal"
 #  - blobs/xx30/extract.sh
 #     To extract from backuped 8M (bottom SPI) ME binary, GBE and IFD blobs.
 
+# Make the Coreboot build depend on the following 3rd party blobs:
+$(build)/coreboot-$(CONFIG_COREBOOT_VERSION)/$(BOARD)/.build: \
+    $(pwd)/blobs/xx30/me.bin
+
+
+$(pwd)/blobs/xx30/me.bin:
+	COREBOOT_DIR="$(build)/$(coreboot_base_dir)" \
+		$(pwd)/blobs/xx30/download_clean_me.sh $(pwd)/blobs/xx30
+
 # Generate split 4MB top / 8MB bottom ROMs
 BOARD_TARGETS := split_8mb4mb

--- a/boards/w530-maximized/w530-maximized.config
+++ b/boards/w530-maximized/w530-maximized.config
@@ -67,22 +67,8 @@ export CONFIG_BOOT_DEV="/dev/sda1"
 export CONFIG_BOARD_NAME="Thinkpad W530-maximized"
 export CONFIG_FLASHROM_OPTIONS="--force --noverify-all -p internal"
 
-# xx30-*-maximized boards require of you initially call one of the
-#  following to have gbe.bin ifd.bin and me.bin
-#  - blobs/xx30/download_clean_me.sh
-#     To download Lenovo original ME binary, neuter+deactivate ME, produce
-#      reduced IFD ME region and expanded BIOS IFD region.
-#  - blobs/xx30/extract.sh
-#     To extract from backuped 8M (bottom SPI) ME binary, GBE and IFD blobs.
-
-# Make the Coreboot build depend on the following 3rd party blobs:
-$(build)/coreboot-$(CONFIG_COREBOOT_VERSION)/$(BOARD)/.build: \
-    $(pwd)/blobs/xx30/me.bin
-
-
-$(pwd)/blobs/xx30/me.bin:
-	COREBOOT_DIR="$(build)/$(coreboot_base_dir)" \
-		$(pwd)/blobs/xx30/download_clean_me.sh $(pwd)/blobs/xx30
+#Include bits related to ivybridge ME blob download/neutering down to BUP+ROMP
+BOARD_TARGETS := xx30_me_blobs
 
 # Generate split 4MB top / 8MB bottom ROMs
-BOARD_TARGETS := split_8mb4mb
+BOARD_TARGETS += split_8mb4mb

--- a/boards/w541-maximized/w541-maximized.config
+++ b/boards/w541-maximized/w541-maximized.config
@@ -53,4 +53,4 @@ $(pwd)/blobs/w541/me.bin:
 		$(pwd)/blobs/w541/download-clean-me $(pwd)/blobs/w541
 
 # Generate split 4MB top / 8MB bottom ROMs
-BOARD_TARGETS := split_8mb4mb
+BOARD_TARGETS += split_8mb4mb

--- a/boards/x220-hotp-maximized/x220-hotp-maximized.config
+++ b/boards/x220-hotp-maximized/x220-hotp-maximized.config
@@ -33,7 +33,6 @@ CONFIG_PCIUTILS=y
 CONFIG_IO386=y
 export CONFIG_FINALIZE_PLATFORM_LOCKING_PRESKYLAKE=y
 
-
 #Remote attestation support
 #TPM based requirements
 export CONFIG_TPM=y
@@ -71,3 +70,12 @@ export CONFIG_FLASHROM_OPTIONS="--force --noverify-all -p internal:ich_spi_mode=
 # xx20 boards require of you initially call one of the following to habe gbe.bin ifd.bin and me.bin
 #  - blobs/xx20/download_parse_me.sh
 #     To download Lenovo update ME binary, neuter+deactivate ME, produce reduced IFD ME region and expended BIOS IFD region.
+
+# Make the Coreboot build depend on the following 3rd party blobs:
+$(build)/coreboot-$(CONFIG_COREBOOT_VERSION)/$(BOARD)/.build: \
+    $(pwd)/blobs/xx20/me.bin
+
+
+$(pwd)/blobs/xx20/me.bin:
+	COREBOOT_DIR="$(build)/$(coreboot_base_dir)" \
+		$(pwd)/blobs/xx20/download_parse_me.sh

--- a/boards/x220-hotp-maximized/x220-hotp-maximized.config
+++ b/boards/x220-hotp-maximized/x220-hotp-maximized.config
@@ -67,15 +67,5 @@ export CONFIG_BOOT_DEV="/dev/sda1"
 export CONFIG_BOARD_NAME="ThinkPad X220-hotp-maximized"
 export CONFIG_FLASHROM_OPTIONS="--force --noverify-all -p internal:ich_spi_mode=hwseq"
 
-# xx20 boards require of you initially call one of the following to habe gbe.bin ifd.bin and me.bin
-#  - blobs/xx20/download_parse_me.sh
-#     To download Lenovo update ME binary, neuter+deactivate ME, produce reduced IFD ME region and expended BIOS IFD region.
-
-# Make the Coreboot build depend on the following 3rd party blobs:
-$(build)/coreboot-$(CONFIG_COREBOOT_VERSION)/$(BOARD)/.build: \
-    $(pwd)/blobs/xx20/me.bin
-
-
-$(pwd)/blobs/xx20/me.bin:
-	COREBOOT_DIR="$(build)/$(coreboot_base_dir)" \
-		$(pwd)/blobs/xx20/download_parse_me.sh
+#Include bits related to sandybridge ME blob download/neutering down to BUP
+BOARD_TARGETS := xx20_me_blobs

--- a/boards/x220-maximized/x220-maximized.config
+++ b/boards/x220-maximized/x220-maximized.config
@@ -33,7 +33,6 @@ CONFIG_PCIUTILS=y
 CONFIG_IO386=y
 export CONFIG_FINALIZE_PLATFORM_LOCKING_PRESKYLAKE=y
 
-
 #Remote attestation support
 #TPM based requirements
 export CONFIG_TPM=y
@@ -71,3 +70,12 @@ export CONFIG_FLASHROM_OPTIONS="--force --noverify-all -p internal:ich_spi_mode=
 # xx20 boards require of you initially call one of the following to habe gbe.bin ifd.bin and me.bin
 #  - blobs/xx20/download_parse_me.sh
 #     To download Lenovo update ME binary, neuter+deactivate ME, produce reduced IFD ME region and expended BIOS IFD region.
+
+# Make the Coreboot build depend on the following 3rd party blobs:
+$(build)/coreboot-$(CONFIG_COREBOOT_VERSION)/$(BOARD)/.build: \
+    $(pwd)/blobs/xx20/me.bin
+
+
+$(pwd)/blobs/xx20/me.bin:
+	COREBOOT_DIR="$(build)/$(coreboot_base_dir)" \
+		$(pwd)/blobs/xx20/download_parse_me.sh

--- a/boards/x220-maximized/x220-maximized.config
+++ b/boards/x220-maximized/x220-maximized.config
@@ -67,15 +67,5 @@ export CONFIG_BOOT_DEV="/dev/sda1"
 export CONFIG_BOARD_NAME="ThinkPad X220-maximized"
 export CONFIG_FLASHROM_OPTIONS="--force --noverify-all -p internal:ich_spi_mode=hwseq"
 
-# xx20 boards require of you initially call one of the following to habe gbe.bin ifd.bin and me.bin
-#  - blobs/xx20/download_parse_me.sh
-#     To download Lenovo update ME binary, neuter+deactivate ME, produce reduced IFD ME region and expended BIOS IFD region.
-
-# Make the Coreboot build depend on the following 3rd party blobs:
-$(build)/coreboot-$(CONFIG_COREBOOT_VERSION)/$(BOARD)/.build: \
-    $(pwd)/blobs/xx20/me.bin
-
-
-$(pwd)/blobs/xx20/me.bin:
-	COREBOOT_DIR="$(build)/$(coreboot_base_dir)" \
-		$(pwd)/blobs/xx20/download_parse_me.sh
+#Include bits related to sandybridge ME blob download/neutering down to BUP
+BOARD_TARGETS += xx20_me_blobs

--- a/boards/x230-hotp-maximized-fhd_edp/x230-hotp-maximized-fhd_edp.config
+++ b/boards/x230-hotp-maximized-fhd_edp/x230-hotp-maximized-fhd_edp.config
@@ -87,5 +87,14 @@ export CONFIG_FLASHROM_OPTIONS="--force --noverify-all -p internal"
 #  - blobs/xx30/extract.sh
 #     To extract from backuped 8M (bottom SPI) ME binary, GBE and IFD blobs.
 
+# Make the Coreboot build depend on the following 3rd party blobs:
+$(build)/coreboot-$(CONFIG_COREBOOT_VERSION)/$(BOARD)/.build: \
+    $(pwd)/blobs/xx30/me.bin
+
+
+$(pwd)/blobs/xx30/me.bin:
+	COREBOOT_DIR="$(build)/$(coreboot_base_dir)" \
+		$(pwd)/blobs/xx30/download_clean_me.sh $(pwd)/blobs/xx30
+
 # Generate split 4MB top / 8MB bottom ROMs
 BOARD_TARGETS := split_8mb4mb

--- a/boards/x230-hotp-maximized-fhd_edp/x230-hotp-maximized-fhd_edp.config
+++ b/boards/x230-hotp-maximized-fhd_edp/x230-hotp-maximized-fhd_edp.config
@@ -79,22 +79,8 @@ export CONFIG_BOOT_DEV="/dev/sda1"
 export CONFIG_BOARD_NAME="Thinkpad X230-hotp-maximized-eDP"
 export CONFIG_FLASHROM_OPTIONS="--force --noverify-all -p internal"
 
-# xx30-*-maximized boards require of you initially call one of the
-#  following to have gbe.bin ifd.bin and me.bin
-#  - blobs/xx30/download_clean_me.sh
-#     To download Lenovo original ME binary, neuter+deactivate ME, produce
-#      reduced IFD ME region and expanded BIOS IFD region.
-#  - blobs/xx30/extract.sh
-#     To extract from backuped 8M (bottom SPI) ME binary, GBE and IFD blobs.
-
-# Make the Coreboot build depend on the following 3rd party blobs:
-$(build)/coreboot-$(CONFIG_COREBOOT_VERSION)/$(BOARD)/.build: \
-    $(pwd)/blobs/xx30/me.bin
-
-
-$(pwd)/blobs/xx30/me.bin:
-	COREBOOT_DIR="$(build)/$(coreboot_base_dir)" \
-		$(pwd)/blobs/xx30/download_clean_me.sh $(pwd)/blobs/xx30
+#Include bits related to ivybridge ME blob download/neutering down to BUP+ROMP
+BOARD_TARGETS := xx30_me_blobs
 
 # Generate split 4MB top / 8MB bottom ROMs
-BOARD_TARGETS := split_8mb4mb
+BOARD_TARGETS += split_8mb4mb

--- a/boards/x230-hotp-maximized/x230-hotp-maximized.config
+++ b/boards/x230-hotp-maximized/x230-hotp-maximized.config
@@ -78,5 +78,14 @@ export CONFIG_FLASHROM_OPTIONS="--force --noverify-all -p internal"
 #  - blobs/xx30/extract.sh
 #     To extract from backuped 8M (bottom SPI) ME binary, GBE and IFD blobs.
 
+# Make the Coreboot build depend on the following 3rd party blobs:
+$(build)/coreboot-$(CONFIG_COREBOOT_VERSION)/$(BOARD)/.build: \
+    $(pwd)/blobs/xx30/me.bin
+
+
+$(pwd)/blobs/xx30/me.bin:
+	COREBOOT_DIR="$(build)/$(coreboot_base_dir)" \
+		$(pwd)/blobs/xx30/download_clean_me.sh $(pwd)/blobs/xx30
+
 # Generate split 4MB top / 8MB bottom ROMs
 BOARD_TARGETS := split_8mb4mb

--- a/boards/x230-hotp-maximized/x230-hotp-maximized.config
+++ b/boards/x230-hotp-maximized/x230-hotp-maximized.config
@@ -70,22 +70,8 @@ export CONFIG_BOOT_DEV="/dev/sda1"
 export CONFIG_BOARD_NAME="Thinkpad X230-hotp-maximized"
 export CONFIG_FLASHROM_OPTIONS="--force --noverify-all -p internal"
 
-# xx30-*-maximized boards require of you initially call one of the
-#  following to have gbe.bin ifd.bin and me.bin
-#  - blobs/xx30/download_clean_me.sh
-#     To download Lenovo original ME binary, neuter+deactivate ME, produce
-#      reduced IFD ME region and expanded BIOS IFD region.
-#  - blobs/xx30/extract.sh
-#     To extract from backuped 8M (bottom SPI) ME binary, GBE and IFD blobs.
-
-# Make the Coreboot build depend on the following 3rd party blobs:
-$(build)/coreboot-$(CONFIG_COREBOOT_VERSION)/$(BOARD)/.build: \
-    $(pwd)/blobs/xx30/me.bin
-
-
-$(pwd)/blobs/xx30/me.bin:
-	COREBOOT_DIR="$(build)/$(coreboot_base_dir)" \
-		$(pwd)/blobs/xx30/download_clean_me.sh $(pwd)/blobs/xx30
+#Include bits related to ivybridge ME blob download/neutering down to BUP+ROMP
+BOARD_TARGETS := xx30_me_blobs
 
 # Generate split 4MB top / 8MB bottom ROMs
-BOARD_TARGETS := split_8mb4mb
+BOARD_TARGETS += split_8mb4mb

--- a/boards/x230-hotp-maximized_usb-kb/x230-hotp-maximized_usb-kb.config
+++ b/boards/x230-hotp-maximized_usb-kb/x230-hotp-maximized_usb-kb.config
@@ -77,5 +77,14 @@ export CONFIG_FLASHROM_OPTIONS="--force --noverify-all -p internal"
 #  - blobs/xx30/extract.sh
 #     To extract from backuped 8M (bottom SPI) ME binary, GBE and IFD blobs.
 
+# Make the Coreboot build depend on the following 3rd party blobs:
+$(build)/coreboot-$(CONFIG_COREBOOT_VERSION)/$(BOARD)/.build: \
+    $(pwd)/blobs/xx30/me.bin
+
+
+$(pwd)/blobs/xx30/me.bin:
+	COREBOOT_DIR="$(build)/$(coreboot_base_dir)" \
+		$(pwd)/blobs/xx30/download_clean_me.sh $(pwd)/blobs/xx30
+
 # Generate split 4MB top / 8MB bottom ROMs
 BOARD_TARGETS := split_8mb4mb

--- a/boards/x230-hotp-maximized_usb-kb/x230-hotp-maximized_usb-kb.config
+++ b/boards/x230-hotp-maximized_usb-kb/x230-hotp-maximized_usb-kb.config
@@ -69,22 +69,8 @@ export CONFIG_BOOT_DEV="/dev/sda1"
 export CONFIG_BOARD_NAME="Thinkpad X230-hotp-maximized_usb-kb"
 export CONFIG_FLASHROM_OPTIONS="--force --noverify-all -p internal"
 
-# xx30-*-maximized boards require of you initially call one of the
-#  following to have gbe.bin ifd.bin and me.bin
-#  - blobs/xx30/download_clean_me.sh
-#     To download Lenovo original ME binary, neuter+deactivate ME, produce
-#      reduced IFD ME region and expanded BIOS IFD region.
-#  - blobs/xx30/extract.sh
-#     To extract from backuped 8M (bottom SPI) ME binary, GBE and IFD blobs.
-
-# Make the Coreboot build depend on the following 3rd party blobs:
-$(build)/coreboot-$(CONFIG_COREBOOT_VERSION)/$(BOARD)/.build: \
-    $(pwd)/blobs/xx30/me.bin
-
-
-$(pwd)/blobs/xx30/me.bin:
-	COREBOOT_DIR="$(build)/$(coreboot_base_dir)" \
-		$(pwd)/blobs/xx30/download_clean_me.sh $(pwd)/blobs/xx30
+#Include bits related to ivybridge ME blob download/neutering down to BUP+ROMP
+BOARD_TARGETS := xx30_me_blobs
 
 # Generate split 4MB top / 8MB bottom ROMs
-BOARD_TARGETS := split_8mb4mb
+BOARD_TARGETS += split_8mb4mb

--- a/boards/x230-maximized-fhd_edp/x230-maximized-fhd_edp.config
+++ b/boards/x230-maximized-fhd_edp/x230-maximized-fhd_edp.config
@@ -79,22 +79,8 @@ export CONFIG_BOOT_DEV="/dev/sda1"
 export CONFIG_BOARD_NAME="Thinkpad X230-maximized-eDP"
 export CONFIG_FLASHROM_OPTIONS="--force --noverify-all -p internal"
 
-# xx30-*-maximized boards require of you initially call one of the
-#  following to have gbe.bin ifd.bin and me.bin
-#  - blobs/xx30/download_clean_me.sh
-#     To download Lenovo original ME binary, neuter+deactivate ME, produce
-#      reduced IFD ME region and expanded BIOS IFD region.
-#  - blobs/xx30/extract.sh
-#     To extract from backuped 8M (bottom SPI) ME binary, GBE and IFD blobs.
-
-# Make the Coreboot build depend on the following 3rd party blobs:
-$(build)/coreboot-$(CONFIG_COREBOOT_VERSION)/$(BOARD)/.build: \
-    $(pwd)/blobs/xx30/me.bin
-
-
-$(pwd)/blobs/xx30/me.bin:
-	COREBOOT_DIR="$(build)/$(coreboot_base_dir)" \
-		$(pwd)/blobs/xx30/download_clean_me.sh $(pwd)/blobs/xx30
+#Include bits related to ivybridge ME blob download/neutering down to BUP+ROMP
+BOARD_TARGETS := xx30_me_blobs
 
 # Generate split 4MB top / 8MB bottom ROMs
-BOARD_TARGETS := split_8mb4mb
+BOARD_TARGETS += split_8mb4mb

--- a/boards/x230-maximized-fhd_edp/x230-maximized-fhd_edp.config
+++ b/boards/x230-maximized-fhd_edp/x230-maximized-fhd_edp.config
@@ -87,5 +87,14 @@ export CONFIG_FLASHROM_OPTIONS="--force --noverify-all -p internal"
 #  - blobs/xx30/extract.sh
 #     To extract from backuped 8M (bottom SPI) ME binary, GBE and IFD blobs.
 
+# Make the Coreboot build depend on the following 3rd party blobs:
+$(build)/coreboot-$(CONFIG_COREBOOT_VERSION)/$(BOARD)/.build: \
+    $(pwd)/blobs/xx30/me.bin
+
+
+$(pwd)/blobs/xx30/me.bin:
+	COREBOOT_DIR="$(build)/$(coreboot_base_dir)" \
+		$(pwd)/blobs/xx30/download_clean_me.sh $(pwd)/blobs/xx30
+
 # Generate split 4MB top / 8MB bottom ROMs
 BOARD_TARGETS := split_8mb4mb

--- a/boards/x230-maximized/x230-maximized.config
+++ b/boards/x230-maximized/x230-maximized.config
@@ -78,5 +78,14 @@ export CONFIG_FLASHROM_OPTIONS="--force --noverify-all -p internal"
 #  - blobs/xx30/extract.sh
 #     To extract from backuped 8M (bottom SPI) ME binary, GBE and IFD blobs.
 
+# Make the Coreboot build depend on the following 3rd party blobs:
+$(build)/coreboot-$(CONFIG_COREBOOT_VERSION)/$(BOARD)/.build: \
+    $(pwd)/blobs/xx30/me.bin
+
+
+$(pwd)/blobs/xx30/me.bin:
+	COREBOOT_DIR="$(build)/$(coreboot_base_dir)" \
+		$(pwd)/blobs/xx30/download_clean_me.sh $(pwd)/blobs/xx30
+
 # Generate split 4MB top / 8MB bottom ROMs
 BOARD_TARGETS := split_8mb4mb

--- a/boards/x230-maximized/x230-maximized.config
+++ b/boards/x230-maximized/x230-maximized.config
@@ -70,22 +70,8 @@ export CONFIG_BOOT_DEV="/dev/sda1"
 export CONFIG_BOARD_NAME="Thinkpad X230-maximized"
 export CONFIG_FLASHROM_OPTIONS="--force --noverify-all -p internal"
 
-# xx30-*-maximized boards require of you initially call one of the
-#  following to have gbe.bin ifd.bin and me.bin
-#  - blobs/xx30/download_clean_me.sh
-#     To download Lenovo original ME binary, neuter+deactivate ME, produce
-#      reduced IFD ME region and expanded BIOS IFD region.
-#  - blobs/xx30/extract.sh
-#     To extract from backuped 8M (bottom SPI) ME binary, GBE and IFD blobs.
-
-# Make the Coreboot build depend on the following 3rd party blobs:
-$(build)/coreboot-$(CONFIG_COREBOOT_VERSION)/$(BOARD)/.build: \
-    $(pwd)/blobs/xx30/me.bin
-
-
-$(pwd)/blobs/xx30/me.bin:
-	COREBOOT_DIR="$(build)/$(coreboot_base_dir)" \
-		$(pwd)/blobs/xx30/download_clean_me.sh $(pwd)/blobs/xx30
+#Include bits related to ivybridge ME blob download/neutering down to BUP+ROMP
+BOARD_TARGETS := xx30_me_blobs
 
 # Generate split 4MB top / 8MB bottom ROMs
-BOARD_TARGETS := split_8mb4mb
+BOARD_TARGETS += split_8mb4mb

--- a/targets/xx20_me_blobs.mk
+++ b/targets/xx20_me_blobs.mk
@@ -1,0 +1,15 @@
+# Targets for downloading xx20 ME blob, neutering it down to BUP region and deactivating ME.
+
+# xx20 boards require of you initially call one of the following to habe gbe.bin ifd.bin and me.bin
+#  - blobs/xx20/download_parse_me.sh
+#     To download Lenovo update ME binary, neuter+deactivate ME, produce reduced IFD ME region and expended BIOS IFD region.
+
+# Make the Coreboot build depend on the following 3rd party blobs:
+$(build)/coreboot-$(CONFIG_COREBOOT_VERSION)/$(BOARD)/.build: \
+	$(pwd)/blobs/xx20/me.bin
+
+
+$(pwd)/blobs/xx20/me.bin:
+	COREBOOT_DIR="$(build)/$(coreboot_base_dir)" \
+		$(pwd)/blobs/xx20/download_parse_me.sh
+

--- a/targets/xx30_me_blobs.mk
+++ b/targets/xx30_me_blobs.mk
@@ -1,0 +1,18 @@
+# Targets for downloading xx30 ME blob, neutering it down to BUP+ROMP region and deactivating ME.
+
+# xx30-*-maximized boards require of you initially call one of the
+#  following to have gbe.bin ifd.bin and me.bin
+#  - blobs/xx30/download_clean_me.sh
+#     To download Lenovo original ME binary, neuter+deactivate ME, produce
+#      reduced IFD ME region and expanded BIOS IFD region.
+#  - blobs/xx30/extract.sh
+#     To extract from backuped 8M (bottom SPI) ME binary, GBE and IFD blobs.
+
+# Make the Coreboot build depend on the following 3rd party blobs:
+$(build)/coreboot-$(CONFIG_COREBOOT_VERSION)/$(BOARD)/.build: \
+    $(pwd)/blobs/xx30/me.bin
+
+
+$(pwd)/blobs/xx30/me.bin:
+	COREBOOT_DIR="$(build)/$(coreboot_base_dir)" \
+		$(pwd)/blobs/xx30/download_clean_me.sh $(pwd)/blobs/xx30


### PR DESCRIPTION
Don't rely on CircleCI prep step instructions to make needed boards blobs available: have the board take charge of that.

- CircleCI still calls BLOBS download scripts directly to download once per prep step.
- Modified me blob download scripts to verify hash of me blobs and only redownload if hash is wrong (user modified)

----

- [x] When CirlceCI builds successfully: revert CircleCI config change so that CircleCI downloads the blobs once in prep step and pass them through workspace cache.