### PR TITLE
modules/cairo: www.cairographics.org down again. Use web.archive.org archive

### DIFF
--- a/modules/cairo
+++ b/modules/cairo
@@ -3,7 +3,7 @@ modules-$(CONFIG_CAIRO) += cairo
 cairo_version := 1.14.12
 cairo_dir := cairo-$(cairo_version)
 cairo_tar := cairo-$(cairo_version).tar.xz
-cairo_url := https://www.cairographics.org/releases/$(cairo_tar)
+cairo_url := https://web.archive.org/web/20230730205546/https://www.cairographics.org/releases/$(cairo_tar)
 cairo_hash := 8c90f00c500b2299c0a323dd9beead2a00353752b2092ead558139bd67f7bf16
 
 cairo_configure := \


### PR DESCRIPTION
Haven't found same archive elsewhere with same hash.
Adds up to https://github.com/linuxboot/heads/issues/1198
