### PR TITLE
initrd/bin/config-gui.sh: Allow configuring automatic boot

### DIFF
--- a/boards/UNTESTED_p8z77-m_pro-tpm1-hotp-maximized/UNTESTED_p8z77-m_pro-tpm1-hotp-maximized.config
+++ b/boards/UNTESTED_p8z77-m_pro-tpm1-hotp-maximized/UNTESTED_p8z77-m_pro-tpm1-hotp-maximized.config
@@ -2,5 +2,6 @@
 include $(pwd)/boards/UNTESTED_p8z77-m_pro-tpm1-maximized/UNTESTED_p8z77-m_pro-tpm1-maximized.config
 
 CONFIG_HOTPKEY=y
+export CONFIG_AUTO_BOOT_TIMEOUT=5
 
 export CONFIG_BOARD_NAME="P8Z77-M PRO-HOTP"

--- a/boards/UNTESTED_t430-hotp-legacy/UNTESTED_t430-hotp-legacy.config
+++ b/boards/UNTESTED_t430-hotp-legacy/UNTESTED_t430-hotp-legacy.config
@@ -37,6 +37,7 @@ CONFIG_TPMTOTP=y
 #HOTP based remote attestation for supported USB Security dongle
 #With/Without TPM support
 CONFIG_HOTPKEY=y
+export CONFIG_AUTO_BOOT_TIMEOUT=5
 
 #Nitrokey Storage admin tool
 CONFIG_NKSTORECLI=n

--- a/boards/UNTESTED_t520-hotp-maximized/UNTESTED_t520-hotp-maximized.config
+++ b/boards/UNTESTED_t520-hotp-maximized/UNTESTED_t520-hotp-maximized.config
@@ -38,6 +38,7 @@ CONFIG_TPMTOTP=y
 #HOTP based remote attestation for supported USB Security dongle
 #With/Without TPM support
 CONFIG_HOTPKEY=y
+export CONFIG_AUTO_BOOT_TIMEOUT=5
 
 #Nitrokey Storage admin tool
 CONFIG_NKSTORECLI=n

--- a/boards/UNTESTED_t530-dgpu-hotp-maximized/UNTESTED_t530-dgpu-hotp-maximized.config
+++ b/boards/UNTESTED_t530-dgpu-hotp-maximized/UNTESTED_t530-dgpu-hotp-maximized.config
@@ -42,6 +42,7 @@ CONFIG_TPMTOTP=y
 #HOTP based remote attestation for supported USB Security dongle
 #With/Without TPM support
 CONFIG_HOTPKEY=y
+export CONFIG_AUTO_BOOT_TIMEOUT=5
 
 #Nitrokey Storage admin tool
 CONFIG_NKSTORECLI=n

--- a/boards/UNTESTED_t530-hotp-maximized/UNTESTED_t530-hotp-maximized.config
+++ b/boards/UNTESTED_t530-hotp-maximized/UNTESTED_t530-hotp-maximized.config
@@ -42,6 +42,7 @@ CONFIG_TPMTOTP=y
 #HOTP based remote attestation for supported USB Security dongle
 #With/Without TPM support
 CONFIG_HOTPKEY=y
+export CONFIG_AUTO_BOOT_TIMEOUT=5
 
 #Nitrokey Storage admin tool
 CONFIG_NKSTORECLI=n

--- a/boards/UNTESTED_w530-dgpu-K1000m-hotp-maximized/UNTESTED_w530-dgpu-K1000m-hotp-maximized.config
+++ b/boards/UNTESTED_w530-dgpu-K1000m-hotp-maximized/UNTESTED_w530-dgpu-K1000m-hotp-maximized.config
@@ -42,6 +42,7 @@ CONFIG_TPMTOTP=y
 #HOTP based remote attestation for supported USB Security dongle
 #With/Without TPM support
 CONFIG_HOTPKEY=y
+export CONFIG_AUTO_BOOT_TIMEOUT=5
 
 #Nitrokey Storage admin tool
 CONFIG_NKSTORECLI=n

--- a/boards/UNTESTED_w530-dgpu-K2000m-hotp-maximized/UNTESTED_w530-dgpu-K2000m-hotp-maximized.config
+++ b/boards/UNTESTED_w530-dgpu-K2000m-hotp-maximized/UNTESTED_w530-dgpu-K2000m-hotp-maximized.config
@@ -42,6 +42,7 @@ CONFIG_TPMTOTP=y
 #HOTP based remote attestation for supported USB Security dongle
 #With/Without TPM support
 CONFIG_HOTPKEY=y
+export CONFIG_AUTO_BOOT_TIMEOUT=5
 
 #Nitrokey Storage admin tool
 CONFIG_NKSTORECLI=n

--- a/boards/qemu-coreboot-fbwhiptail-tpm1-hotp/qemu-coreboot-fbwhiptail-tpm1-hotp.config
+++ b/boards/qemu-coreboot-fbwhiptail-tpm1-hotp/qemu-coreboot-fbwhiptail-tpm1-hotp.config
@@ -37,6 +37,7 @@ CONFIG_MBEDTLS=y
 CONFIG_DROPBEAR=y
 CONFIG_MSRTOOLS=y
 CONFIG_HOTPKEY=y
+export CONFIG_AUTO_BOOT_TIMEOUT=5
 
 #Uncomment only one of the following block
 #Required for graphical gui-init (FBWhiptail)

--- a/boards/qemu-coreboot-fbwhiptail-tpm2-hotp/qemu-coreboot-fbwhiptail-tpm2-hotp.config
+++ b/boards/qemu-coreboot-fbwhiptail-tpm2-hotp/qemu-coreboot-fbwhiptail-tpm2-hotp.config
@@ -38,6 +38,7 @@ CONFIG_MBEDTLS=y
 CONFIG_DROPBEAR=y
 CONFIG_MSRTOOLS=y
 CONFIG_HOTPKEY=y
+export CONFIG_AUTO_BOOT_TIMEOUT=5
 
 #Uncomment only one of the following block
 #Required for graphical gui-init (FBWhiptail)

--- a/boards/qemu-coreboot-whiptail-tpm1-hotp/qemu-coreboot-whiptail-tpm1-hotp.config
+++ b/boards/qemu-coreboot-whiptail-tpm1-hotp/qemu-coreboot-whiptail-tpm1-hotp.config
@@ -37,6 +37,7 @@ CONFIG_MBEDTLS=y
 CONFIG_DROPBEAR=y
 CONFIG_MSRTOOLS=y
 CONFIG_HOTPKEY=y
+export CONFIG_AUTO_BOOT_TIMEOUT=5
 
 #Uncomment only one of the following block
 #Required for graphical gui-init (FBWhiptail)

--- a/boards/qemu-coreboot-whiptail-tpm2-hotp/qemu-coreboot-whiptail-tpm2-hotp.config
+++ b/boards/qemu-coreboot-whiptail-tpm2-hotp/qemu-coreboot-whiptail-tpm2-hotp.config
@@ -38,6 +38,7 @@ CONFIG_MBEDTLS=y
 CONFIG_DROPBEAR=y
 CONFIG_MSRTOOLS=y
 CONFIG_HOTPKEY=y
+export CONFIG_AUTO_BOOT_TIMEOUT=5
 
 #Uncomment only one of the following block
 #Required for graphical gui-init (FBWhiptail)

--- a/boards/t420-hotp-maximized/t420-hotp-maximized.config
+++ b/boards/t420-hotp-maximized/t420-hotp-maximized.config
@@ -42,6 +42,7 @@ CONFIG_TPMTOTP=y
 #HOTP based remote attestation for supported USB Security dongle
 #With/Without TPM support
 CONFIG_HOTPKEY=y
+export CONFIG_AUTO_BOOT_TIMEOUT=5
 
 #Nitrokey Storage admin tool
 CONFIG_NKSTORECLI=n

--- a/boards/t430-hotp-maximized/t430-hotp-maximized.config
+++ b/boards/t430-hotp-maximized/t430-hotp-maximized.config
@@ -40,6 +40,7 @@ CONFIG_TPMTOTP=y
 #HOTP based remote attestation for supported USB Security dongle
 #With/Without TPM support
 CONFIG_HOTPKEY=y
+export CONFIG_AUTO_BOOT_TIMEOUT=5
 
 #Nitrokey Storage admin tool
 CONFIG_NKSTORECLI=n

--- a/boards/t440p-hotp-maximized/t440p-hotp-maximized.config
+++ b/boards/t440p-hotp-maximized/t440p-hotp-maximized.config
@@ -2,5 +2,6 @@
 include $(pwd)/boards/t440p-maximized/t440p-maximized.config
 
 CONFIG_HOTPKEY=y
+export CONFIG_AUTO_BOOT_TIMEOUT=5
 
 export CONFIG_BOARD_NAME="ThinkPad T440p-hotp-maximized"

--- a/boards/w530-hotp-maximized/w530-hotp-maximized.config
+++ b/boards/w530-hotp-maximized/w530-hotp-maximized.config
@@ -42,6 +42,7 @@ CONFIG_TPMTOTP=y
 #HOTP based remote attestation for supported USB Security dongle
 #With/Without TPM support
 CONFIG_HOTPKEY=y
+export CONFIG_AUTO_BOOT_TIMEOUT=5
 
 #Nitrokey Storage admin tool
 CONFIG_NKSTORECLI=n

--- a/boards/w541-hotp-maximized/w541-hotp-maximized.config
+++ b/boards/w541-hotp-maximized/w541-hotp-maximized.config
@@ -2,5 +2,6 @@
 include $(pwd)/boards/w541-maximized/w541-maximized.config
 
 CONFIG_HOTPKEY=y
+export CONFIG_AUTO_BOOT_TIMEOUT=5
 
 export CONFIG_BOARD_NAME="ThinkPad W541-hotp-maximized"

--- a/boards/x220-hotp-maximized/x220-hotp-maximized.config
+++ b/boards/x220-hotp-maximized/x220-hotp-maximized.config
@@ -42,6 +42,7 @@ CONFIG_TPMTOTP=y
 #HOTP based remote attestation for supported USB Security dongle
 #With/Without TPM support
 CONFIG_HOTPKEY=y
+export CONFIG_AUTO_BOOT_TIMEOUT=5
 
 #Nitrokey Storage admin tool
 CONFIG_NKSTORECLI=n

--- a/boards/x230-hotp-legacy/x230-hotp-legacy.config
+++ b/boards/x230-hotp-legacy/x230-hotp-legacy.config
@@ -37,6 +37,7 @@ CONFIG_TPMTOTP=y
 #HOTP based remote attestation for supported USB Security dongle
 #With/Without TPM support
 CONFIG_HOTPKEY=y
+export CONFIG_AUTO_BOOT_TIMEOUT=5
 
 #Nitrokey Storage admin tool
 CONFIG_NKSTORECLI=n

--- a/boards/x230-hotp-maximized-fhd_edp/x230-hotp-maximized-fhd_edp.config
+++ b/boards/x230-hotp-maximized-fhd_edp/x230-hotp-maximized-fhd_edp.config
@@ -54,6 +54,7 @@ CONFIG_TPMTOTP=y
 #HOTP based remote attestation for supported USB Security dongle
 #With/Without TPM support
 CONFIG_HOTPKEY=y
+export CONFIG_AUTO_BOOT_TIMEOUT=5
 
 #Nitrokey Storage admin tool
 CONFIG_NKSTORECLI=n

--- a/boards/x230-hotp-maximized/x230-hotp-maximized.config
+++ b/boards/x230-hotp-maximized/x230-hotp-maximized.config
@@ -45,6 +45,7 @@ CONFIG_TPMTOTP=y
 #HOTP based remote attestation for supported USB Security dongle
 #With/Without TPM support
 CONFIG_HOTPKEY=y
+export CONFIG_AUTO_BOOT_TIMEOUT=5
 
 #Nitrokey Storage admin tool
 CONFIG_NKSTORECLI=n

--- a/boards/x230-hotp-maximized_usb-kb/x230-hotp-maximized_usb-kb.config
+++ b/boards/x230-hotp-maximized_usb-kb/x230-hotp-maximized_usb-kb.config
@@ -44,6 +44,7 @@ CONFIG_TPMTOTP=y
 #HOTP based remote attestation for supported USB Security dongle
 #With/Without TPM support
 CONFIG_HOTPKEY=y
+export CONFIG_AUTO_BOOT_TIMEOUT=5
 
 #Nitrokey Storage admin tool
 CONFIG_NKSTORECLI=n

--- a/boards/z220-cmt-hotp-maximized/z220-cmt-hotp-maximized.config
+++ b/boards/z220-cmt-hotp-maximized/z220-cmt-hotp-maximized.config
@@ -2,5 +2,6 @@
 include $(pwd)/boards/z220-cmt-maximized/z220-cmt-maximized.config
 
 CONFIG_HOTPKEY=y
+export CONFIG_AUTO_BOOT_TIMEOUT=5
 
 export CONFIG_BOARD_NAME="Hewlett-Packard Z220 Convertible Minitower (HOTP)"


### PR DESCRIPTION
Automatic boot can be configured in the configuration GUI.  Options are disable, 1 second, 5 seconds, or 10 seconds.

Users asked me for this :grin: 

Closes #1441 (where @3hhh request for 3s is not in yet, but PR welcome)