### PR TITLE
initrd/bin/seal-hotpkey: Show error if /boot can't be mounted

### DIFF
--- a/initrd/bin/seal-hotpkey
+++ b/initrd/bin/seal-hotpkey
@@ -11,9 +11,12 @@ mount_boot()
 {
   TRACE "Under /bin/seal-hotpkey:mount_boot"
   # Mount local disk if it is not already mounted
-  if ! grep -q /boot /proc/mounts ; then
-    mount -o ro /boot \
-      || recovery "Unable to mount /boot"
+  if ! grep -q /boot /proc/mounts; then
+    if ! mount -o ro /boot; then
+      whiptail $BG_COLOR_ERROR --title 'ERROR' \
+        --msgbox "Couldn't mount /boot.\n\nCheck the /boot device in configuration settings, or perform an OEM reset." 0 80
+      return 1
+    fi
   fi
 }
 
@@ -45,7 +48,7 @@ fi
 # Store counter in file instead of TPM for now, as it conflicts with Heads
 # config TPM counter as TPM 1.2 can only increment one counter between reboots
 # get current value of HOTP counter in TPM, create if absent
-mount_boot
+mount_boot || exit 1
 
 #check_tpm_counter $HOTP_COUNTER hotp \
 #|| die "Unable to find/create TPM counter"


### PR DESCRIPTION
If we can't mount /boot, show a meaningful error rather than dropping to a recovery shell.

Dropping to a recovery shell should be a last resort.  Users that know how to use the recovery shell know how to get there.  Users that don't know how to use it can be completely stuck and may not know how to get back to the menu or even how to turn off the device.

This happened to a user after reinstalling the OS.  PureBoot offered to re-seal TOTP/HOTP, but attempting to do so just went to recovery because the old /boot partition no longer existed, there wasn't any clear path to get the system back in working order.

The easiest way to test this is to just remove the SSD, then attempt to boot and seal TOTP/HOTP.