### PR TITLE
Show error messages for various media errors in flash-gui.sh

### DIFF
--- a/initrd/bin/flash-gui.sh
+++ b/initrd/bin/flash-gui.sh
@@ -113,12 +113,12 @@ while true; do
           # talos-2 uses a .tgz file for its "plain" update, contains other parts as well, validated against hashes under flash.sh
           # Skip prompt for hash validation for talos-2. Only method is through tgz or through bmc with individual parts
           if [ "${CONFIG_BOARD%_*}" != talos-2 ]; then
-          # a rom file was provided. exit if we shall not proceed
-          ROM="$PKG_FILE"
-          ROM_HASH=$(sha256sum "$ROM" | awk '{print $1}') || die "Failed to hash ROM file"
-          if ! (whiptail $CONFIG_ERROR_BG_COLOR --title 'Flash ROM without integrity check?' \
-            --yesno "You have provided a *.$UPDATE_PLAIN_EXT file. The integrity of the file can not be\nchecked automatically for this file type.\n\nROM: $ROM\nSHA256SUM: $ROM_HASH\n\nIf you do not know how to check the file integrity yourself,\nyou should use a *.zip file instead.\n\nIf the file is damaged, you will not be able to boot anymore.\nDo you want to proceed flashing without file integrity check?" 0 80); then
-            exit 1
+            # a rom file was provided. exit if we shall not proceed
+            ROM="$PKG_FILE"
+            ROM_HASH=$(sha256sum "$ROM" | awk '{print $1}') || die "Failed to hash ROM file"
+            if ! (whiptail $CONFIG_ERROR_BG_COLOR --title 'Flash ROM without integrity check?' \
+              --yesno "You have provided a *.$UPDATE_PLAIN_EXT file. The integrity of the file can not be\nchecked automatically for this file type.\n\nROM: $ROM\nSHA256SUM: $ROM_HASH\n\nIf you do not know how to check the file integrity yourself,\nyou should use a *.zip file instead.\n\nIf the file is damaged, you will not be able to boot anymore.\nDo you want to proceed flashing without file integrity check?" 0 80); then
+              exit 1
             fi
           else
             #We are on talos-2, so we have a tgz file. We will pass it directly to flash.sh which will take care of it


### PR DESCRIPTION
Show messages for media errors in flash-gui.sh, either when enumerating ROMs or reading a plain ROM.  (Reading a ZIP package is already OK, the unzip fails and it falls through to the integrity check error.)

A user had I/O errors when enumerating ROMs, which just returns to the main menu with no explanation.  (find errors will be on the recovery console.)  Show an error in that case suggesting to check the disk, reformat, or try a different disk.

I believe the user's case was due to filesystem corruption, but I can reproduce the same find errors with the following:
* With an ancient/slow flash drive, produce a lot of dummy files so the 'find' will take long enough to yank the disk
    * `for i in $(seq 1 50000); do dd if=/dev/urandom bs=1K count=1 of=<disk>/$(printf rom%05i.rom $i) status=none; done` (this ended after ~31K files for me, out of inodes on a 128 MB disk)
* Plug in this flash drive and at least one other (to be sure the disk is yanked after mounting)
* Go through the flash GUI menus, select the dummy disk
* While the 'find' is enumerating, yank the disk
    * master will just kick back to the main menu, errors can be seen on the console
    * PR will show a message

Additionally, show a similar message if the ROM itself is unreadable.  Copy the ROM to /tmp before using it, handle I/O errors there, then use the copy in /tmp from then on to avoid any problems with the medium.  This is reproducible just by yanking the disk during the ROM menu, then selecting any ROM.  This didn't occur in the field, but it's a similar failure mode.