### PR TITLE
bin/fetch_coreboot_crossgcc_archive.sh: ln -s again if link exists

### DIFF
--- a/bin/fetch_coreboot_crossgcc_archive.sh
+++ b/bin/fetch_coreboot_crossgcc_archive.sh
@@ -128,5 +128,6 @@ BIN_DIR="$(dirname "${BASH_SOURCE[0]}")"
 mkdir -p "$COREBOOT_DIR/util/crossgcc/tarballs"
 (
 	cd "$COREBOOT_DIR/util/crossgcc/tarballs"
+	rm -f "$PKG_BASENAME"
 	ln -s "$PKGS_DIR/coreboot-crossgcc-$PKG_BASENAME" "$PKG_BASENAME"
 )


### PR DESCRIPTION
Changes in things like modules/coreboot will check the coreboot toolchain archives again.  We reuse the cached archive already, but the final ln -s may fail if the link already exists.  Remove it first and link again.