### PR TITLE
ppc64le builder required changes

### DIFF
--- a/modules/gpg2
+++ b/modules/gpg2
@@ -5,7 +5,7 @@ gpg2_dir := gnupg-$(gpg2_version)
 gpg2_tar := gnupg-$(gpg2_version).tar.bz2
 gpg2_url := https://www.gnupg.org/ftp/gcrypt/gnupg/$(gpg2_tar)
 gpg2_hash := 1d79158dd01d992431dd2e3facb89fdac97127f89784ea2cb610c600fb0c1483
-gpg2_depends := libgpg-error libgcrypt libksba libassuan npth libusb-compat $(musl_dep)
+gpg2_depends := libgpg-error libgcrypt libksba libassuan npth libusb $(musl_dep)
 
 # For reproducibility reasons we have to override the exec_prefix
 # and datarootdir on the configure line so that the Makefiles will

--- a/modules/libusb-compat
+++ b/modules/libusb-compat
@@ -3,7 +3,6 @@
 # This is a bit of a hack to set it up.
 
 modules-$(CONFIG_GPG) += libusb-compat
-modules-$(CONFIG_GPG2) += libusb-compat
 
 libusb-compat_version := 0.1.5
 libusb-compat_dir := libusb-compat-$(libusb-compat_version)

--- a/modules/popt
+++ b/modules/popt
@@ -1,15 +1,16 @@
 modules-$(CONFIG_POPT) += popt
 
-popt_version := 1.16
+popt_version := 1.19
 popt_dir := popt-$(popt_version)
 popt_tar := popt-$(popt_version).tar.gz
-popt_url := https://launchpad.net/popt/head/$(popt_version)/+download/$(popt_tar)
-popt_hash := e728ed296fe9f069a0e005003c3d6b2dde3d9cad453422a10d6558616d304cc8
+popt_url := https://fossies.org/linux/misc/$(popt_tar)
+popt_hash := c25a4838fc8e4c1c8aacb8bd620edb3084a3d63bf8987fdad3ca2758c63240f9
 
 popt_configure := ./configure \
 	$(CROSS_TOOLS) \
 	--prefix "/" \
 	--host $(MUSL_ARCH)-elf-linux \
+
 
 popt_target := \
 	$(MAKE_JOBS) \
@@ -20,6 +21,6 @@ popt_target := \
 		DESTDIR="$(INSTALL)" \
 		install
 
-popt_libraries := .libs/libpopt.so.0
+popt_libraries := src/.libs/libpopt.so.0
 
 popt_depends := $(musl_dep)


### PR DESCRIPTION
popt: too old to have a working config.guess (2009. version bump) 
libusb-compat: not needed for gpg2. Adapt into module (reverse dep hack not needed in module anymore) 
gpg2: depend on libusb not libusb-compat