### PR TITLE
Fix TPM DUK retry loop (bogus), uniformize related vocabulary

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -110,7 +110,7 @@ to deceive you and steal your login password?  Maybe!  It wouldn't get
 your disk password, which is perhaps an improvement.
 
 
-Disk key in TPM (TPM Disk Unlock Key) or user passphrase?
+Disk key in TPM (LUKS TPM Disk Unlock Key) or user passphrase?
 ---
 Depends on your threat model.  With the disk key in the TPM an attacker
 would need to have the entire machine (or a backdoor in the TPM)

--- a/initrd/bin/kexec-insert-key
+++ b/initrd/bin/kexec-insert-key
@@ -45,6 +45,7 @@ mkdir -p "$INITRD_DIR/etc"
 unseal_failed="n"
 if ! kexec-unseal-key "$INITRD_DIR/secret.key"; then
 	unseal_failed="y"
+	echo
 	echo "!!! Failed to unseal the TPM LUKS disk key"
 fi
 

--- a/initrd/bin/kexec-insert-key
+++ b/initrd/bin/kexec-insert-key
@@ -59,7 +59,7 @@ if [ "$unseal_failed" = "y" ]; then
 	confirm_boot="n"
 	read \
 		-n 1 \
-		-p "Do you wish to boot and use the disk recovery key? [Y/n] " \
+		-p "Do you wish to boot and use the LUKS Disk Recovery Key? [Y/n] " \
 		confirm_boot
 
 	if [ "$confirm_boot" != 'y' \

--- a/initrd/bin/kexec-save-default
+++ b/initrd/bin/kexec-save-default
@@ -189,10 +189,10 @@ save_key="n"
 
 if [ "$CONFIG_TPM" = "y" ] && [ "$CONFIG_TPM_NO_LUKS_DISK_UNLOCK" != "y" ] && [ "$CONFIG_BASIC" != y ]; then
 	DEBUG "TPM is enabled and TPM_NO_LUKS_DISK_UNLOCK is not set"
-	DEBUG "Checking if a a TPM Disk Unlock Key was previously set up from $KEY_DEVICES"
+	DEBUG "Checking if a a LUKS TPM Disk Unlock Key was previously set up from $KEY_DEVICES"
 	#check if $KEY_DEVICES file exists and is not empty
 	if [ -r "$KEY_DEVICES" ] && [ -s "$KEY_DEVICES" ]; then
-		DEBUG "TPM Disk Unlock Key was previously set up from $KEY_DEVICES"
+		DEBUG "LUKS TPM Disk Unlock Key was previously set up from $KEY_DEVICES"
 		read \
 			-n 1 \
 			-p "Do you want to reseal a disk key to the TPM [y/N]: " \
@@ -218,7 +218,7 @@ if [ "$CONFIG_TPM" = "y" ] && [ "$CONFIG_TPM_NO_LUKS_DISK_UNLOCK" != "y" ] && [ 
 			save_key="y"
 		fi
 	else
-		DEBUG "No previous TPM Disk Unlock Key was set up for LUKS devices, confirming to add a Disk Encryption Key to the TPM"
+		DEBUG "No previous LUKS TPM Disk Unlock Key was set up, confirming to add a Disk Encryption Key to the TPM"
 		read \
 			-n 1 \
 			-p "Do you wish to add a disk encryption to the TPM [y/N]: " \
@@ -234,7 +234,7 @@ if [ "$CONFIG_TPM" = "y" ] && [ "$CONFIG_TPM_NO_LUKS_DISK_UNLOCK" != "y" ] && [ 
 
 	if [ "$save_key" = "y" ]; then
 		if [ -n "$old_key_devices" ] || [ -n "$old_lvm_volume_group" ]; then
-			DEBUG "Previous TPM Disk Unlock Key was set up for LUKS devices $old_key_devices $old_lvm_volume_group"
+			DEBUG "Previous LUKS TPM Disk Unlock Key was set up for $old_key_devices $old_lvm_volume_group"
 			read \
 				-n 1 \
 				-p "Do you want to reuse configured Encrypted LVM groups/Block devices? (Y/n):" \
@@ -252,7 +252,7 @@ if [ "$CONFIG_TPM" = "y" ] && [ "$CONFIG_TPM_NO_LUKS_DISK_UNLOCK" != "y" ] && [ 
 				prompt_for_existing_encrypted_lvms_or_disks
 			fi
 		else
-			DEBUG "No previous TPM Disk Unlock Key was set up for LUKS devices, setting up new one"
+			DEBUG "No previous LUKS TPM Disk Unlock Key was set up, setting up"
 			prompt_for_existing_encrypted_lvms_or_disks
 		fi
 
@@ -263,7 +263,7 @@ if [ "$CONFIG_TPM" = "y" ] && [ "$CONFIG_TPM_NO_LUKS_DISK_UNLOCK" != "y" ] && [ 
 			save_key_params="$save_key_params $key_devices"
 		fi
 		kexec-save-key $save_key_params ||
-			die "Failed to save the TPM Disk Unlock Key"
+			die "Failed to save the LUKS TPM Disk Unlock Key"
 	fi
 fi
 

--- a/initrd/bin/kexec-save-key
+++ b/initrd/bin/kexec-save-key
@@ -72,7 +72,7 @@ for dev in $key_devices; do
 done
 
 kexec-seal-key $paramsdir ||
-	die "Failed to save and generate TPM Disk Unlock Key"
+	die "Failed to save and generate LUKS TPM Disk Unlock Key"
 
 if [ "$skip_sign" != "y" ]; then
 	extparam=

--- a/initrd/bin/kexec-seal-key
+++ b/initrd/bin/kexec-seal-key
@@ -74,12 +74,31 @@ dd \
 for dev in $(cat "$KEY_DEVICES" | cut -d\  -f1); do
 	DEBUG "Checking number of slots used on $dev LUKS header"
 	#check if the device is a LUKS device with luks[1,2]
-	slots_used=$(cryptsetup luksDump $dev | grep -c 'luks[0-9]*' || die "Unable to get number of slots used on $dev")
+	# Get the number of key slots used on the LUKS header.
+	# LUKS1 Format is :
+	# Slot 0: ENABLED
+	# Slot 1: ENABLED
+	# Slot 2: DISABLED
+	# Slot 3: DISABLED
+	#...
+	# Slot 7: DISABLED
+	# Luks2 only reports on enabled slots.
+	# luks2 Format is :
+	# 0: luks2
+	# 1: luks2
+	#  Meaning that the number of slots used is the number of lines returned by a grep on the LUKS2 above format.
+	# We need to count the number of ENABLED slots for both LUKS1 and LUKS2
+	# create regex pattern for both LUKS1 and LUKS2
+	regex="Slot [0-9]*: ENABLED"
+	regex+="\|"
+	regex+="[0-9]*: luks2"
+	slots_used=$(cryptsetup luksDump "$dev" | grep -c "$regex" || die "Unable to get number of slots used on $dev")
+
 	DEBUG "Number of slots used on $dev LUKS header: $slots_used"
 	# If slot1 is the only one used, warn and die with proper messages
-	if [ $slots_used -eq 1 ]; then
+	if [ "$slots_used" -eq 1 ]; then
 		# Check if slot 1 is the only one existing
-		if cryptsetup luksDump $dev | grep -q "Slot 1: ENABLED"; then
+		if [ "$(cryptsetup luksDump "$dev" | grep -c "Slot 1: ENABLED")" -eq 1 ] || [ "$(cryptsetup luksDump "$dev" | grep -c "1: luks2")" -eq 1 ]; then
 			warn "Slot 1 is the only one existing on $dev LUKS header. Heads cannot use it to store TPM sealed LUKS Disk Unlock Key"
 			warn "Slot 1 should not be the only slot existing on $dev LUKS header. Slot 0 should be used to store Disk Recovery Key/passphrase"
 			die "You can safely fix this before continuing through Heads recovery shell: cryptsetup luksAddKey $dev"
@@ -92,18 +111,18 @@ done
 
 # Remove all the old keys from slot 1
 for dev in $(cat "$KEY_DEVICES" | cut -d\  -f1); do
-	echo "++++++ $dev: Removing old key slot 1"
+	echo "++++++ $dev: Removing old TPM Disk Unlock Key in LUKS slot 1"
 	cryptsetup luksKillSlot \
 		--key-file "$RECOVERY_KEY" \
 		$dev 1 ||
-		warn "$dev: removal of key in slot 1 failed: might not exist. Continuing"
+		warn "$dev: removal of TPM Disk Unlock Key in LUKS slot 1 failed: might not exist. Continuing"
 
-	echo "++++++ $dev: Adding key to slot 1"
+	echo "++++++ $dev: Adding TPM Disk Unlock Key to LUKS slot 1"
 	cryptsetup luksAddKey \
 		--key-file "$RECOVERY_KEY" \
 		--key-slot 1 \
 		$dev "$KEY_FILE" ||
-		die "$dev: Unable to add key to slot 1"
+		die "$dev: Unable to add TPM Disk Unlock Key to LUKS slot 1"
 done
 
 # Now that we have setup the new keys, measure the PCRs

--- a/initrd/bin/kexec-seal-key
+++ b/initrd/bin/kexec-seal-key
@@ -47,13 +47,13 @@ DEBUG "$(pcrs)"
 # LUKS Key slot 0 is the manual recovery pass phrase
 # that they user entered when they installed OS,
 # key slot 1 is the one that we've generated.
-read -s -p "Enter Disk Recovery Key/passphrase: " disk_password
+read -s -p "Enter LUKS Disk Recovery Key/passphrase: " disk_password
 echo -n "$disk_password" >"$RECOVERY_KEY"
 echo
 
-read -s -p "New TPM Disk Unlock Key passphrase for booting: " key_password
+read -s -p "New LUKS TPM Disk Unlock Key passphrase for booting: " key_password
 echo
-read -s -p "Repeat TPM Disk Unlock Key passphrase for booting: " key_password2
+read -s -p "Repeat LUKS TPM Disk Unlock Key passphrase for booting: " key_password2
 echo
 
 if [ "$key_password" != "$key_password2" ]; then
@@ -61,7 +61,7 @@ if [ "$key_password" != "$key_password2" ]; then
 fi
 
 # Generate key file
-echo "++++++ Generating new randomized 128 bytes key file that will be sealed/unsealed by TPM Disk Unlock Key passphrase"
+echo "++++++ Generating new randomized 128 bytes key file that will be sealed/unsealed by LUKS TPM Disk Unlock Key passphrase"
 dd \
 	if=/dev/urandom \
 	of="$KEY_FILE" \
@@ -100,29 +100,29 @@ for dev in $(cat "$KEY_DEVICES" | cut -d\  -f1); do
 		# Check if slot 1 is the only one existing
 		if [ "$(cryptsetup luksDump "$dev" | grep -c "Slot 1: ENABLED")" -eq 1 ] || [ "$(cryptsetup luksDump "$dev" | grep -c "1: luks2")" -eq 1 ]; then
 			warn "Slot 1 is the only one existing on $dev LUKS header. Heads cannot use it to store TPM sealed LUKS Disk Unlock Key"
-			warn "Slot 1 should not be the only slot existing on $dev LUKS header. Slot 0 should be used to store Disk Recovery Key/passphrase"
+			warn "Slot 1 should not be the only slot existing on $dev LUKS header. Slot 0 should be used to store LUKS Disk Recovery Key/passphrase"
 			die "You can safely fix this before continuing through Heads recovery shell: cryptsetup luksAddKey $dev"
 		fi
 	else
 		DEBUG "Slot 1 is not the only existing slot on $dev LUKS header."
-		DEBUG "$dev LUKS header's slot 1 will store LUKS Disk Unlock Key that TPM will seal/unseal with TPM Disk Unlock Key passphrase"
+		DEBUG "$dev LUKS header's slot 1 will store LUKS Disk Unlock Key that TPM will seal/unseal with LUKS TPM Disk Unlock Key passphrase"
 	fi
 done
 
 # Remove all the old keys from slot 1
 for dev in $(cat "$KEY_DEVICES" | cut -d\  -f1); do
-	echo "++++++ $dev: Removing old TPM Disk Unlock Key in LUKS slot 1"
+	echo "++++++ $dev: Removing old LUKS TPM Disk Unlock Key in LUKS slot 1"
 	cryptsetup luksKillSlot \
 		--key-file "$RECOVERY_KEY" \
 		$dev 1 ||
-		warn "$dev: removal of TPM Disk Unlock Key in LUKS slot 1 failed: might not exist. Continuing"
+		warn "$dev: removal of LUKS TPM Disk Unlock Key in LUKS slot 1 failed: might not exist. Continuing"
 
-	echo "++++++ $dev: Adding TPM Disk Unlock Key to LUKS slot 1"
+	echo "++++++ $dev: Adding LUKS TPM Disk Unlock Key to LUKS slot 1"
 	cryptsetup luksAddKey \
 		--key-file "$RECOVERY_KEY" \
 		--key-slot 1 \
 		$dev "$KEY_FILE" ||
-		die "$dev: Unable to add TPM Disk Unlock Key to LUKS slot 1"
+		die "$dev: Unable to add LUKS TPM Disk Unlock Key to LUKS slot 1"
 done
 
 # Now that we have setup the new keys, measure the PCRs
@@ -140,23 +140,23 @@ tpmr pcrread -a 3 "$pcrf"
 # Note that PCR 4 needs to be set with the "normal-boot" path value, read it from event log.
 tpmr calcfuturepcr 4 >>"$pcrf"
 if [ "$CONFIG_USB_KEYBOARD" = "y" -o -r /lib/modules/libata.ko -o -x /bin/hotp_verification ]; then
-	DEBUG "Sealing TPM Disk Unlock key with PCR5 involvement (additional kernel modules are loaded per board config)..."
+	DEBUG "Sealing LUKS TPM Disk Unlock Key with PCR5 involvement (additional kernel modules are loaded per board config)..."
 	# Here, we take pcr 5 into consideration if modules are expected to be measured+loaded
 	tpmr pcrread -a 5 "$pcrf"
 else
-	DEBUG "Sealing TPM Disk Unlock Key with PCR5=0 (NO additional kernel modules are loaded per board config)..."
+	DEBUG "Sealing LUKS TPM Disk Unlock Key with PCR5=0 (NO additional kernel modules are loaded per board config)..."
 	#no kernel modules are expected to be measured+loaded
 	tpmr calcfuturepcr 5 >>"$pcrf"
 fi
 # Precompute the value for pcr 6
-DEBUG "Precomputing TPM future value for PCR6 sealing/unsealing of TPM Disk Unlock Key..."
+DEBUG "Precomputing TPM future value for PCR6 sealing/unsealing of LUKS TPM Disk Unlock Key..."
 tpmr calcfuturepcr 6 "/tmp/luksDump.txt" >>"$pcrf"
 # We take into consideration user files in cbfs
 tpmr pcrread -a 7 "$pcrf"
 
 DO_WITH_DEBUG --mask-position 7 \
 	tpmr seal "$KEY_FILE" "$TPM_INDEX" 0,1,2,3,4,5,6,7 "$pcrf" \
-	"$TPM_SIZE" "$key_password" || die "Unable to write TPM Disk Unlock Key to NVRAM"
+	"$TPM_SIZE" "$key_password" || die "Unable to write LUKS TPM Disk Unlock Key to NVRAM"
 
 # should be okay if this fails
 shred -n 10 -z -u "$pcrf" 2>/dev/null ||

--- a/initrd/bin/kexec-unseal-key
+++ b/initrd/bin/kexec-unseal-key
@@ -26,17 +26,15 @@ DEBUG "Show PCRs"
 DEBUG "$(pcrs)"
 
 for tries in 1 2 3; do
-	read -s -p "Enter LUKS Disk Unlock Key passphrase (blank to abort): " tpm_password
+	read -s -p "Enter LUKS TPM Disk Unlock Key passphrase (blank to abort): " tpm_password
 	echo
 	if [ -z "$tpm_password" ]; then
 		die "Aborting unseal disk encryption key"
 	fi
 
-	DO_WITH_DEBUG --mask-position 6 \
+	if DO_WITH_DEBUG --mask-position 6 \
 		tpmr unseal "$TPM_INDEX" "0,1,2,3,4,5,6,7" "$TPM_SIZE" \
-		"$key_file" "$tpm_password"
-
-	if [ "$?" -eq 0 ]; then
+		"$key_file" "$tpm_password"; then
 		exit 0
 	fi
 

--- a/initrd/bin/kexec-unseal-key
+++ b/initrd/bin/kexec-unseal-key
@@ -38,7 +38,7 @@ for tries in 1 2 3; do
 		exit 0
 	fi
 
-	pcrs
+	DEBUG $(pcrs)
 	warn "Unable to unseal disk encryption key"
 done
 

--- a/initrd/bin/oem-factory-reset
+++ b/initrd/bin/oem-factory-reset
@@ -626,7 +626,7 @@ generate_checksums() {
         mount -o remount,rw /boot || whiptail_error_die "Unable to mount /boot"
     fi
 
-    #Check if previous TPM Disk unlock Key was set
+    #Check if previous LUKS TPM Disk Unlock Key was set
     if [ -e /boot/kexec_key_devices.txt ]; then
         TPM_DISK_ENCRYPTION_KEY_SET=1
     fi
@@ -657,7 +657,7 @@ generate_checksums() {
         fi
     fi
 
-    # set default boot option only if no TPM Disk Unlock Key previously set
+    # set default boot option only if no LUKS TPM Disk Unlock Key previously set
     if [ -z "$TPM_DISK_ENCRYPTION_KEY_SET" ]; then
         set_default_boot_option
     fi
@@ -903,7 +903,7 @@ if [ "$use_defaults" == "n" -o "$use_defaults" == "N" ]; then
         echo -e "\n"
     fi
 
-    echo -e -n "Would you like to re-encrypt LUKS encrypted container and generate new Disk Recovery key?\n (Highly recommended if you didn't install the operating system yourself: this would prevent any LUKS backed up header to be restored to access encrypted data) [y/N]: "
+    echo -e -n "Would you like to re-encrypt LUKS encrypted container and generate new LUKS Disk Recovery Key?\n (Highly recommended if you didn't install the operating system yourself: this would prevent any LUKS backed up header to be restored to access encrypted data) [y/N]: "
     read -n 1 prompt_output
     echo
     if [ "$prompt_output" == "y" \
@@ -1022,13 +1022,13 @@ if [ "$use_defaults" == "n" -o "$use_defaults" == "N" ]; then
     if [ -n "$luks_new_Disk_Recovery_Key_passphrase_desired" -a -z "$luks_new_Disk_Recovery_Key_passphrase" ]; then
         # We catch here if changing LUKS Disk Recovery Key passphrase was desired
         #  but yet undone. This is if not being covered by the single password
-        echo -e "\nEnter desired replacement for current Disk Recovery Key passphrase (At least 8 characters long):"
+        echo -e "\nEnter desired replacement for current LUKS Disk Recovery Key passphrase (At least 8 characters long):"
         while [[ ${#luks_new_Disk_Recovery_Key_passphrase} -lt 8 ]]; do
             {
                 read -r luks_new_Disk_Recovery_Key_passphrase
             }
         done
-        #We test that current Disk Recovery Key passphrase is known prior of going further
+        #We test that current LUKS Disk Recovery Key passphrase is known prior of going further
         test_luks_current_disk_recovery_key_passphrase
         echo -e "\n"
     fi
@@ -1147,7 +1147,7 @@ if [[ "$SKIP_BOOT" == "n" ]]; then
 fi
 
 if [ -n "$luks_new_Disk_Recovery_Key_desired" -a -n "$luks_new_Disk_Recovery_Key_passphrase_desired" ]; then
-    #Reencryption of disk, disk recovery key and Disk Recovery Key passphrase change is requested
+    #Reencryption of disk, LUKS Disk Recovery Key and LUKS Disk Recovery Key passphrase change is requested
     luks_change_passphrase
     luks_reencrypt
 elif [ -n "$luks_new_Disk_Recovery_Key_desired" -a -z "$luks_new_Disk_Recovery_Key_passphrase_desired" ]; then

--- a/initrd/etc/functions
+++ b/initrd/etc/functions
@@ -82,12 +82,12 @@ confirm_totp() {
 
 reseal_tpm_disk_decryption_key() {
 	TRACE "Under /etc/functions:reseal_tpm_disk_decryption_key"
-	#For robustness, exit early if TPM Disk Unlock Key is prohibited in board configs
+	#For robustness, exit early if LUKS TPM Disk Unlock Key is prohibited in board configs
 	if [ "$CONFIG_TPM_DISK_UNLOCK_KEY" == "n" ]; then
-		DEBUG "TPM Disk Unlock Key is prohibited in board configs"
+		DEBUG "LUKS TPM Disk Unlock Key is prohibited in board configs"
 		return
 	else
-		DEBUG "TPM Disk Unlock Key is allowed in board configs. Continuing"
+		DEBUG "LUKS TPM Disk Unlock Key is allowed in board configs. Continuing"
 	fi
 
 	if ! grep -q /boot /proc/mounts; then
@@ -96,8 +96,8 @@ reseal_tpm_disk_decryption_key() {
 	fi
 
 	if [ -s /boot/kexec_key_devices.txt ] || [ -s /boot/kexec_key_lvm.txt ]; then
-		warn "TPM sealed Disk Unlock Key secret needs to be resealed alongside TOTP/HOTP secret"
-		echo "Resealing TPM LUKS Disk Unlock Key to be unsealed by TPM Disk Unlock Key passphrase"
+		warn "LUKS TPM sealed Disk Unlock Key secret needs to be resealed alongside TOTP/HOTP secret"
+		echo "Resealing LUKS TPM Disk Unlock Key to be unsealed by LUKS TPM Disk Unlock Key passphrase"
 		while ! kexec-seal-key /boot; do
 			warn "Recovery Disk Encryption key passphrase/TPM Owner Password may be invalid. Please try again"
 		done

--- a/initrd/etc/luks-functions
+++ b/initrd/etc/luks-functions
@@ -299,15 +299,15 @@ test_luks_current_disk_recovery_key_passphrase()
 	while :; do
 		select_luks_container || return 1
 		if [ -z "$luks_current_Disk_Recovery_Key_passphrase" ]; then
-			#if no external provisioning provides current Disk Recovery Key passphrase
-			echo -e "\nEnter the current Disk Recovery Key passphrase (Configured at OS installation or by OEM):"
+			#if no external provisioning provides current LUKS Disk Recovery Key passphrase
+			echo -e "\nEnter the current LUKS Disk Recovery Key passphrase (Configured at OS installation or by OEM):"
 			read -r luks_current_Disk_Recovery_Key_passphrase
 			echo -n "$luks_current_Disk_Recovery_Key_passphrase" >/tmp/luks_current_Disk_Recovery_Key_passphrase
-			warn "Testing opening "$LUKS" LUKS encrypted drive content with the current Disk Recovery Key passphrase..."
+			warn "Testing opening "$LUKS" LUKS encrypted drive content with the current LUKS Disk Recovery Key passphrase..."
 			cryptsetup open $LUKS test --key-file /tmp/luks_current_Disk_Recovery_Key_passphrase
 		else
 			echo -n "$luks_current_Disk_Recovery_Key_passphrase" >/tmp/luks_current_Disk_Recovery_Key_passphrase
-			warn "Testing opening "$LUKS" LUKS encrypted drive content with the current Disk Recovery Key passphrase..."
+			warn "Testing opening "$LUKS" LUKS encrypted drive content with the current LUKS Disk Recovery Key passphrase..."
 			cryptsetup open $LUKS test --key-file /tmp/luks_current_Disk_Recovery_Key_passphrase
 		fi
 		#Validate past cryptsetup-reencrypt attempts
@@ -315,7 +315,7 @@ test_luks_current_disk_recovery_key_passphrase()
 			whiptail --title 'Invalid Actual LUKS Disk Recovery Key passphrase?' --msgbox \
 				"If you previously changed it and do not remember it, you will have to\n reinstall the OS from a an external drive.\n\nTo do so, place the ISO file and its signature file on root of an\n external drive, and select Options-> Boot from USB \n\nHit Enter to retry." 30 60
 			shred -n 10 -z -u /tmp/luks_current_Disk_Recovery_Key_passphrase 2>/dev/null
-			#unsetting luks_current_Disk_Recovery_Key_passphrase so we prompt for it again Disk Recovery Key passphrase prompt on next round
+			#unsetting luks_current_Disk_Recovery_Key_passphrase so we prompt for it again LUKS Disk Recovery Key passphrase prompt on next round
 			unset luks_current_Disk_Recovery_Key_passphrase
 			#remove "known good" selected LUKS container so that next pass asks again user to select LUKS container.
 			#maybe the container was not the right one
@@ -339,22 +339,23 @@ luks_reencrypt() {
 	TRACE "Under /etc/luks-functions:luks_reencrypt()"
 	while :; do
 		select_luks_container || return 1
-                #If the user just set a new Disk Recovery Key passphrase
+                #If the user just set a new LUKS Disk Recovery Key passphrase
                 if [ -n "$luks_new_Disk_Recovery_Key_passphrase" ]; then
                         luks_current_Disk_Recovery_Key_passphrase="$luks_new_Disk_Recovery_Key_passphrase"
                 fi
 		if [ -z "$luks_current_Disk_Recovery_Key_passphrase" ]; then
-			#if no external provisioning provides current Disk Recovery Key passphrase
+			#if no external provisioning provides current LUKS Disk Recovery Key passphrase
+			msg=$(echo -e "This will replace the encrypted container content and its LUKS Disk Recovery Key.\n\nThe passphrase associated with this key will be asked from the user under the following conditions:\n 1-Every boot if no Disk Unlock Key was added to the TPM\n 2-If the TPM fails (hardware failure)\n 3-If the firmware has been tampered with/modified by the user\n\nThis process requires you to type the current LUKS Disk Recovery Key passphrase and will delete the LUKS TPM Disk Unlock Key slot, if set up, by setting a default boot LUKS key slot (1) if present.\n\nAt the next prompt, you may be asked to select which file corresponds to the LUKS device container.\n\nHit Enter to continue." | fold -w 70 -s)
 			whiptail --title 'Reencrypt LUKS encrypted container ?' \
-			--msgbox "This will replace the encrypted container content and its Disk Recovery Key.\n\nThe passphrase associated with this key will be asked from the user under\nthe following conditions:\n 1-Every boot if no Disk Unlock Key was added to the TPM\n 2-If the TPM fails (hardware failure)\n 3-If the firmware has been tampered with/upgraded/modified by the user\n\nThis process requires you to type the current Disk Recovery Key passphrase\nand will delete the TPM Disk Unlock Key slot, if set up, by setting a default\n boot LUKS key slot (1) if present.\n\nAt the next prompt, you may be asked to select which file corresponds to\nthe LUKS device container.\n\nHit Enter to continue." 0 80
-			echo -e "\nEnter the current Disk Recovery Key passphrase:"
+			--msgbox "$msg" 0 80
+			echo -e "\nEnter the current LUKS Disk Recovery Key passphrase:"
 			read -r luks_current_Disk_Recovery_Key_passphrase
 			echo -n "$luks_current_Disk_Recovery_Key_passphrase" >/tmp/luks_current_Disk_Recovery_Key_passphrase
-			warn "Reencrypting "$LUKS" LUKS encrypted drive content with a new Disk Recovery Key. Do NOT shut down or reboot!"
+			warn "Reencrypting "$LUKS" LUKS encrypted drive content with a new LUKS Disk Recovery Key. Do NOT shut down or reboot!"
 			cryptsetup-reencrypt -B 64 --use-directio "$LUKS" --key-slot 0 --key-file /tmp/luks_current_Disk_Recovery_Key_passphrase
 		else
 			echo -n "$luks_current_Disk_Recovery_Key_passphrase" >/tmp/luks_current_Disk_Recovery_Key_passphrase
-			warn "Reencrypting "$LUKS" LUKS encrypted drive content with a new Disk Recovery Key. Do NOT shut down or reboot!"
+			warn "Reencrypting "$LUKS" LUKS encrypted drive content with a new LUKS Disk Recovery Key. Do NOT shut down or reboot!"
 			cryptsetup-reencrypt -B 64 --use-directio "$LUKS" --key-slot 0 --key-file /tmp/luks_current_Disk_Recovery_Key_passphrase
 		fi
 		#Validate past cryptsetup-reencrypt attempts
@@ -362,7 +363,7 @@ luks_reencrypt() {
 			whiptail --title 'Invalid Actual LUKS Disk Recovery Key passphrase?' --msgbox \
 				"If you previously changed it and do not remember it, you will have to\n reinstall the OS from a an external drive.\n\nTo do so, place the ISO file and its signature file on root of an\n external drive, and select Options-> Boot from USB \n\nHit Enter to retry." 30 60
 			shred -n 10 -z -u /tmp/luks_current_Disk_Recovery_Key_passphrase 2>/dev/null
-			#unsetting luks_current_Disk_Recovery_Key_passphrase so we prompt for it again Disk Recovery Key passphrase prompt on next round
+			#unsetting luks_current_Disk_Recovery_Key_passphrase so we prompt for it again LUKS Disk Recovery Key passphrase prompt on next round
 			unset luks_current_Disk_Recovery_Key_passphrase
 			#remove "known good" selected LUKS container so that next pass asks again user to select LUKS container.
 			#maybe the container was not the right one
@@ -384,32 +385,32 @@ luks_change_passphrase()
 	TRACE "Under /etc/luks-functions:luks_change_passphrase()"
 	while :; do
 		select_luks_container || return 1
-		#if actual or new Disk Recovery Key is not provisioned by oem-provisioning file
+		#if actual or new LUKS Disk Recovery Key is not provisioned by oem-provisioning file
 		if [ -z "$luks_current_Disk_Recovery_Key_passphrase" ] || [ -z "$luks_new_Disk_Recovery_Key_passphrase" ]; then
 			whiptail --title 'Changing LUKS Disk Recovery Key passphrase' --msgbox \
-				"Please enter the current Disk Recovery Key passphrase (slot 0).\nThen choose a strong passphrase of your own.\n\n**DICEWARE passphrase methodology is STRONGLY ADVISED.**\n\nHit Enter to continue" 30 60
+				"Please enter the current LUKS Disk Recovery Key passphrase (slot 0).\nThen choose a strong passphrase of your own.\n\n**DICEWARE passphrase methodology is STRONGLY ADVISED.**\n\nHit Enter to continue" 30 60
 			if [ -z "$luks_new_Disk_Recovery_Key_passphrase" ]; then
-				echo -e "\nEnter your desired replacement for the actual Disk Recovery Key passphrase (At least 8 characters long):"
+				echo -e "\nEnter your desired replacement for the actual LUKS Disk Recovery Key passphrase (At least 8 characters long):"
 				while [[ ${#luks_new_Disk_Recovery_Key_passphrase} -lt 8 ]]; do
 				{
 					read -r luks_new_Disk_Recovery_Key_passphrase
 			        };done
 			fi
 			if [ -z "$luks_current_Disk_Recovery_Key_passphrase" ]; then
-				echo -e "\nEnter the current Disk Recovery Key passphrase (Configured at OS installation or by OEM):"
+				echo -e "\nEnter the current LUKS Disk Recovery Key passphrase (Configured at OS installation or by OEM):"
 				read -r luks_current_Disk_Recovery_Key_passphrase
 			fi
 			export luks_current_Disk_Recovery_Key_passphrase
 			export luks_new_Disk_Recovery_Key_passphrase
 			echo -n "$luks_new_Disk_Recovery_Key_passphrase" >/tmp/luks_new_Disk_Recovery_Key_passphrase
 			echo -n "$luks_current_Disk_Recovery_Key_passphrase" >/tmp/luks_current_Disk_Recovery_Key_passphrase
-			warn "Changing "$LUKS" LUKS encrypted disk passphrase to the new Disk Recovery Key passphrase..."
+			warn "Changing "$LUKS" LUKS encrypted disk passphrase to the new LUKS Disk Recovery Key passphrase..."
 			cryptsetup luksChangeKey "$LUKS" --key-slot 0 --key-file=/tmp/luks_current_Disk_Recovery_Key_passphrase /tmp/luks_new_Disk_Recovery_Key_passphrase
 		else
-			#If current and new Disk Recovery Key were exported
+			#If current and new LUKS Disk Recovery Key were exported
 			echo -n "$luks_new_Disk_Recovery_Key_passphrase" >/tmp/luks_new_Disk_Recovery_Key_passphrase
 			echo -n "$luks_current_Disk_Recovery_Key_passphrase" >/tmp/luks_current_Disk_Recovery_Key_passphrase
-			warn "Changing "$LUKS" LUKS encrypted disk passphrase to the new Disk Recovery Key passphrase..."
+			warn "Changing "$LUKS" LUKS encrypted disk passphrase to the new LUKS Disk Recovery Key passphrase..."
 			cryptsetup luksChangeKey "$LUKS" --key-slot 0 --key-file=/tmp/luks_current_Disk_Recovery_Key_passphrase /tmp/luks_new_Disk_Recovery_Key_passphrase
 		fi
 

--- a/modules/zstd
+++ b/modules/zstd
@@ -1,5 +1,5 @@
 # ZSTD is always included, unless explicitly turned off
-# Needed by initrd/bin/unpack_initramfs.sh under TPM Disk Unlock Key setup
+# Needed by initrd/bin/unpack_initramfs.sh under LUKS TPM Disk Unlock Key setup
 CONFIG_ZSTD ?= y
 modules-$(CONFIG_ZSTD) += zstd
 


### PR DESCRIPTION
#1588 related: fixes retry. Left behind: capslock key detection and fix.

@JonathonHall-Purism please review


Tested:
- lukskillslot of slot 1 when two available.
- lukschangepassword without specifying slot so that slot 0 LUKS Disk Recovery Key is put under slot1 where no slot 0 exist.
  -  on TPM DUK addition, warning showed to user to repair manual config which is unsupported
  - when manually fixed as suggested, both slot 1 and slot 0 exist and Heads detects and warns correctly on both LUSKv1 and LUKSv2
- TPM DUK loops for 1/3 to 3/3 and warns that capslock might be the cause of failing.
- After 3 bad attempts, normal codepath continue proposing user to type LUKS Disk Recovery Key password in OS.


Basically, the loop code was bogues because of pipefail, TPM DUK passphrase failing to unseal caused pipefail and exiting without retrying input as codepath expected.


TODO: find a nice way to get capslock state from tty. Only way found as of now would be through kbd, and extracting ioctl call to tty to get state of key modifiers. That is estimated to be 7kb of compiled c code that would need to be an independent app. I have not found any other easy way to get capslock state. Reminder, there is no capslock led on old lenovos, and exposing those leds through kernel modules successfully exposes capclock but since EC firmware doesn't interact in any way with abent leds, the state cannot be read from LEDs so not an alternative solution. If anybody has an idea that could go through exposed /sys /proc or even agetty/stty, I tried a lot but didn't succeed. @JonathonHall-Purism  ideas there?   