### PR TITLE
coreboot-nitrokey: hard-code ME state during boot

### DIFF
--- a/patches/coreboot-nitrokey-clevo_release/0002-dasharo-hardcode-me.patch
+++ b/patches/coreboot-nitrokey-clevo_release/0002-dasharo-hardcode-me.patch
@@ -1,0 +1,12 @@
+diff -ur coreboot-nitrokey.org/src/vendorcode/dasharo/options.c coreboot-nitrokey/src/vendorcode/dasharo/options.c
+--- coreboot-nitrokey.org/src/vendorcode/dasharo/options.c	2024-01-22 14:11:59.525612567 +0100
++++ coreboot-nitrokey/src/vendorcode/dasharo/options.c	2024-01-22 14:12:07.535544365 +0100
+@@ -133,7 +133,7 @@
+ 	if (CONFIG(DRIVERS_EFI_VARIABLE_STORE))
+ 		read_u8_var("MeMode", &var);
+ 
+-	return var;
++	return ME_MODE_DISABLE_HAP;
+ }
+ 
+ bool is_smm_bwp_permitted(void)


### PR DESCRIPTION
fixes Nitrokey/heads#39

Dasharo v1.7.2 introduced a feature to always set the ME state during boot based on the EDK2 defined values. 
This led to the ME being activated in Nitrokey's v2.4 release, this PR fixes this by hard-coding the EDK2 defined values.

This PR is intentionally minimal to minimize testing and release fast - the Nitropad releases, will be build from this [branch](https://github.com/Nitrokey/heads/tree/nitropad-release-v2.4.1). 

We are currently testing - it affects anyways the `coreboot-nitrokey` module exclusively - so don't see further needs for testing - we will not only test our branch, but also the upstream artifacts. Once the tests are done I will promote this PR to "ready-for-review".