### PR TITLE
all scripts: replace TRACE manual strings with dynamic tracing by bash debug

### DIFF
--- a/initrd/bin/cbfs-init
+++ b/initrd/bin/cbfs-init
@@ -2,7 +2,7 @@
 set -e -o pipefail
 . /etc/functions
 
-TRACE "Under /bin/cbfs-init"
+TRACE_FUNC
 
 # Update initrd with CBFS files
 if [ -z "$CONFIG_PCR" ]; then

--- a/initrd/bin/cbfs.sh
+++ b/initrd/bin/cbfs.sh
@@ -3,7 +3,7 @@ set -e -o pipefail
 . /etc/functions
 . /tmp/config
 
-TRACE "Under /bin/cbfs.sh"
+TRACE_FUNC
 
 if pnor "$2" -r HBI > /tmp/pnor.part 2>/dev/null; then
     cbfs "$@" -o /tmp/pnor.part && pnor "$2" -w HBI < /tmp/pnor.part

--- a/initrd/bin/config-gui.sh
+++ b/initrd/bin/config-gui.sh
@@ -5,7 +5,7 @@ set -e -o pipefail
 . /etc/gui_functions
 . /tmp/config
 
-TRACE "Under /bin/config-gui.sh"
+TRACE_FUNC
 
 ROOT_HASH_FILE="/boot/kexec_root_hashes.txt"
 

--- a/initrd/bin/flash-gui.sh
+++ b/initrd/bin/flash-gui.sh
@@ -5,7 +5,7 @@ set -e -o pipefail
 . /etc/gui_functions
 . /tmp/config
 
-TRACE "Under /bin/flash-gui.sh"
+TRACE_FUNC
 
 if [ "$CONFIG_RESTRICTED_BOOT" = y ]; then
   whiptail $BG_COLOR_ERROR --title 'Restricted Boot Active' \

--- a/initrd/bin/flashrom-kgpe-d16-openbmc.sh
+++ b/initrd/bin/flashrom-kgpe-d16-openbmc.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 . /etc/functions
 
-TRACE "Under /bin/flashrom-kgpe-d16-openbmc.sh"
+TRACE_FUNC
 
 ROM="$1"
 if [ -z "$1" ]; then

--- a/initrd/bin/generic-init
+++ b/initrd/bin/generic-init
@@ -6,7 +6,7 @@
 
 mount_boot()
 {
-	TRACE "Under /bin/generic-init:mount_boot"
+	TRACE_FUNC
 	# Mount local disk if it is not already mounted
 	if ! grep -q /boot /proc/mounts ; then
 		mount -o ro /boot \

--- a/initrd/bin/gpg-gui.sh
+++ b/initrd/bin/gpg-gui.sh
@@ -5,7 +5,7 @@ set -e -o pipefail
 . /etc/gui_functions
 . /tmp/config
 
-TRACE "Under /bin/gpg-gui.sh"
+TRACE_FUNC
 gpg_flash_rom() {
 
   if [ "$1" = "replace" ]; then

--- a/initrd/bin/gpgv
+++ b/initrd/bin/gpgv
@@ -2,5 +2,5 @@
 # if we are using the full GPG we need a wrapper for the gpgv executable
 . /etc/functions
 
-TRACE "Under /bin/gpgv"
+TRACE_FUNC
 exec gpg --verify "$@"

--- a/initrd/bin/gui-init
+++ b/initrd/bin/gui-init
@@ -18,7 +18,7 @@ skip_to_menu="false"
 
 mount_boot()
 {
-  TRACE "Under /bin/gui-init:mount_boot"
+  TRACE_FUNC
   # Mount local disk if it is not already mounted
   while ! grep -q /boot /proc/mounts ; do
     # try to mount if CONFIG_BOOT_DEV exists
@@ -64,7 +64,7 @@ mount_boot()
 
 verify_global_hashes()
 {
-  TRACE "Under /bin/gui-init:verify_global_hashes"
+  TRACE_FUNC
   # Check the hashes of all the files, ignoring signatures for now
   check_config /boot force
   TMP_HASH_FILE="/tmp/kexec/kexec_hashes.txt"
@@ -139,7 +139,7 @@ verify_global_hashes()
 
 prompt_update_checksums()
 {
-  TRACE "Under /bin/gui-init:prompt_update_checksums"
+  TRACE_FUNC
   if (whiptail $BG_COLOR_WARNING --title 'Update Checksums and sign all files in /boot' \
       --yesno "You have chosen to update the checksums and sign all of the files in /boot.\n\nThis means that you trust that these files have not been tampered with.\n\nYou will need your GPG key available, and this change will modify your disk.\n\nDo you want to continue?" 0 80) then
     if ! update_checksums ; then
@@ -151,7 +151,7 @@ prompt_update_checksums()
 
 generate_totp_hotp()
 {
-  TRACE "Under /bin/gui-init:generate_totp_hotp"  
+  TRACE_FUNC  
   tpm_owner_password="$1"	# May be empty, will prompt if needed and empty
   if [ "$CONFIG_TPM" != "y" ] && [ -x /bin/hotp_verification ]; then
     echo "Generating new HOTP secret"
@@ -180,7 +180,7 @@ generate_totp_hotp()
 
 update_totp()
 {
-  TRACE "Under /bin/gui-init:update_totp"
+  TRACE_FUNC
   # update the TOTP code
   date=`date "+%Y-%m-%d %H:%M:%S %Z"`
   tries=0
@@ -249,7 +249,7 @@ update_totp()
 
 update_hotp()
 {
-  TRACE "Under /bin/gui-init:update_hotp"
+  TRACE_FUNC
   if [ -x /bin/hotp_verification ]; then
     HOTP=`unseal-hotp`
     if ! hotp_verification info ; then
@@ -313,7 +313,7 @@ update_hotp()
 
 clean_boot_check()
 {
-  TRACE "Under /bin/gui-init:clean_boot_check"
+  TRACE_FUNC
   # assume /boot mounted
   if ! grep -q /boot /proc/mounts ; then
     return
@@ -342,7 +342,7 @@ clean_boot_check()
 
 check_gpg_key()
 {
-  TRACE "Under /bin/gui-init:check_gpg_key"
+  TRACE_FUNC
   GPG_KEY_COUNT=`gpg -k 2>/dev/null | wc -l`
   if [ $GPG_KEY_COUNT -eq 0 ]; then
     BG_COLOR_MAIN_MENU=$BG_COLOR_ERROR
@@ -379,7 +379,7 @@ check_gpg_key()
 
 prompt_auto_default_boot()
 {
-  TRACE "Under /bin/gui-init:prompt_auto_default_boot"
+  TRACE_FUNC
   echo -e "\nHOTP verification success\n\n"
   if pause_automatic_boot; then
     echo -e "\n\nAttempting default boot...\n\n"
@@ -389,7 +389,7 @@ prompt_auto_default_boot()
 
 show_main_menu()
 {
-  TRACE "Under /bin/gui-init:show_main_menu"
+  TRACE_FUNC
   date=`date "+%Y-%m-%d %H:%M:%S %Z"`
   whiptail $BG_COLOR_MAIN_MENU --title "$MAIN_MENU_TITLE" \
     --menu "$date\nTOTP: $TOTP | HOTP: $HOTP" 0 80 10 \
@@ -422,7 +422,7 @@ show_main_menu()
 
 show_options_menu()
 {
-  TRACE "Under /bin/gui-init:show_options_menu"
+  TRACE_FUNC
   whiptail $BG_COLOR_MAIN_MENU --title "$CONFIG_BRAND_NAME Options" \
     --menu "" 0 80 10 \
     'b' ' Boot Options -->' \
@@ -483,7 +483,7 @@ show_options_menu()
 
 show_boot_options_menu()
 {
-  TRACE "Under /bin/gui-init:show_boot_options_menu"
+  TRACE_FUNC
   whiptail $BG_COLOR_MAIN_MENU --title "Boot Options" \
     --menu "Select A Boot Option" 0 80 10 \
     'm' ' Show OS boot menu' \
@@ -511,7 +511,7 @@ show_boot_options_menu()
 
 show_tpm_totp_hotp_options_menu()
 {
-  TRACE "Under /bin/gui-init:show_tpm_totp_hotp_options_menu"
+  TRACE_FUNC
   whiptail $BG_COLOR_MAIN_MENU --title "TPM/TOTP/HOTP Options" \
     --menu "Select An Option" 0 80 10 \
     'g' ' Generate new TOTP/HOTP secret' \
@@ -538,7 +538,7 @@ show_tpm_totp_hotp_options_menu()
 
 prompt_totp_mismatch()
 {
-  TRACE "Under /bin/gui-init:prompt_totp_mismatch"
+  TRACE_FUNC
   if (whiptail $BG_COLOR_WARNING --title "TOTP/HOTP code mismatched" \
     --yesno "TOTP/HOTP code mismatches could indicate either TPM tampering or clock drift:\n\nTo correct clock drift: 'date -s yyyy-MM-DD hh:mm:ss' in UTC timezone\nand save it to the RTC: 'hwclock -w'\nthen reboot and try again.\n\nWould you like to exit to a recovery console?" 0 80) then
     echo ""
@@ -555,7 +555,7 @@ prompt_totp_mismatch()
 
 reset_tpm()
 {
-  TRACE "Under /bin/gui-init:reset_tpm"
+  TRACE_FUNC
   if [ "$CONFIG_TPM" = "y" ]; then
     if (whiptail $BG_COLOR_WARNING --title 'Reset the TPM' \
         --yesno "This will clear the TPM and TPM password, replace them with new ones!\n\nDo you want to proceed?" 0 80) then
@@ -599,7 +599,7 @@ reset_tpm()
 
 select_os_boot_option()
 {
-  TRACE "Under /bin/gui-init:select_os_boot_option"
+  TRACE_FUNC
   mount_boot
   if verify_global_hashes ; then
     kexec-select-boot -m -b /boot -c "grub.cfg" -g
@@ -608,7 +608,7 @@ select_os_boot_option()
 
 attempt_default_boot()
 {
-  TRACE "Under /bin/gui-init:attempt_default_boot"
+  TRACE_FUNC
   mount_boot
     
   if ! verify_global_hashes; then
@@ -626,7 +626,7 @@ attempt_default_boot()
 
 force_unsafe_boot()
 {
-  TRACE "Under /bin/gui-init:force_unsafe_boot"
+  TRACE_FUNC
   if [ "$CONFIG_RESTRICTED_BOOT" = y ]; then
       whiptail $BG_COLOR_ERROR --title 'ERROR: Restricted Boot Enabled' --msgbox "Restricted Boot is Enabled, forced boot not allowed.\n\nPress OK to return to the Main Menu" 0 80
       return
@@ -639,7 +639,7 @@ force_unsafe_boot()
 }
 
 # gui-init start
-TRACE "Under /bin/gui-init, start"
+TRACE_FUNC
 
 # Use stored HOTP key branding
 if [ -r /boot/kexec_hotp_key ]; then
@@ -673,7 +673,7 @@ if [ "$HOTP" = "Success" -a -n "$CONFIG_AUTO_BOOT_TIMEOUT" ]; then
 fi
 
 while true; do
-  TRACE "Under gui-init:while true loop"
+  TRACE_FUNC
   skip_to_menu="false"
   show_main_menu
 done

--- a/initrd/bin/gui-init-basic
+++ b/initrd/bin/gui-init-basic
@@ -17,7 +17,7 @@ skip_to_menu="false"
 
 mount_boot()
 {
-  TRACE "Under /bin/gui-init:mount_boot"
+  TRACE_FUNC
   # Mount local disk if it is not already mounted
   while ! grep -q /boot /proc/mounts ; do
     # try to mount if CONFIG_BOOT_DEV exists
@@ -63,7 +63,7 @@ mount_boot()
 
 prompt_auto_default_boot()
 {
-  TRACE "Under /bin/gui-init:prompt_auto_default_boot"
+  TRACE_FUNC
   echo -e "\n\n"
   if pause_automatic_boot; then
     echo -e "\n\nAttempting default boot...\n\n"
@@ -73,7 +73,7 @@ prompt_auto_default_boot()
 
 show_main_menu()
 {
-  TRACE "Under /bin/gui-init:show_main_menu"
+  TRACE_FUNC
   date=`date "+%Y-%m-%d %H:%M:%S %Z"`
   whiptail $BG_COLOR_MAIN_MENU --title "$MAIN_MENU_TITLE" \
     --menu "$date" 0 80 10 \
@@ -102,7 +102,7 @@ show_main_menu()
 
 show_options_menu()
 {
-  TRACE "Under /bin/gui-init:show_options_menu"
+  TRACE_FUNC
   whiptail $BG_COLOR_MAIN_MENU --title "$CONFIG_BRAND_NAME Basic Options" \
     --menu "" 0 80 10 \
     'b' ' Boot Options -->' \
@@ -133,7 +133,7 @@ show_options_menu()
 
 show_boot_options_menu()
 {
-  TRACE "Under /bin/gui-init:show_boot_options_menu"
+  TRACE_FUNC
   whiptail $BG_COLOR_MAIN_MENU --title "Boot Options" \
     --menu "Select A Boot Option" 0 80 10 \
     'm' ' Show OS boot menu' \
@@ -157,14 +157,14 @@ show_boot_options_menu()
 
 select_os_boot_option()
 {
-  TRACE "Under /bin/gui-init:select_os_boot_option"
+  TRACE_FUNC
   mount_boot
   kexec-select-boot -m -b /boot -c "grub.cfg" -g -i
 }
 
 attempt_default_boot()
 {
-  TRACE "Under /bin/gui-init:attempt_default_boot"
+  TRACE_FUNC
   mount_boot
 
   DEFAULT_FILE=`find /boot/kexec_default.*.txt 2>/dev/null | head -1`
@@ -183,7 +183,7 @@ attempt_default_boot()
 }
 
 # gui-init-basic start
-TRACE "Under /bin/gui-init, start"
+TRACE_FUNC
 
 # USB automatic boot (if configured) occurs before mounting /boot, this should
 # work even if no OS is installed
@@ -204,7 +204,7 @@ if [ "$skip_to_menu" != "true" -a -n "$CONFIG_AUTO_BOOT_TIMEOUT" ]; then
 fi
 
 while true; do
-  TRACE "Under gui-init:while true loop"
+  TRACE_FUNC
   skip_to_menu="false"
   show_main_menu
 done

--- a/initrd/bin/kexec-boot
+++ b/initrd/bin/kexec-boot
@@ -4,7 +4,7 @@ set -e -o pipefail
 . /tmp/config
 . /etc/functions
 
-TRACE "Under /bin/kexec-boot"
+TRACE_FUNC
 
 dryrun="n"
 printfiles="n"

--- a/initrd/bin/kexec-insert-key
+++ b/initrd/bin/kexec-insert-key
@@ -3,7 +3,7 @@
 set -e -o pipefail
 . /etc/functions
 
-TRACE "Under /bin/kexec-insert-key"
+TRACE_FUNC
 
 TMP_KEY_DEVICES="/tmp/kexec/kexec_key_devices.txt"
 TMP_KEY_LVM="/tmp/kexec/kexec_key_lvm.txt"

--- a/initrd/bin/kexec-iso-init
+++ b/initrd/bin/kexec-iso-init
@@ -4,7 +4,7 @@ set -e -o pipefail
 . /etc/functions
 . /tmp/config
 
-TRACE "Under /bin/kexec-iso-init"
+TRACE_FUNC
 
 MOUNTED_ISO_PATH="$1"
 ISO_PATH="$2"

--- a/initrd/bin/kexec-parse-bls
+++ b/initrd/bin/kexec-parse-bls
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e -o pipefail
 . /etc/functions
-TRACE "Under /bin/kexec-parse-bls"
+TRACE_FUNC
 
 bootdir="$1"
 file="$2"

--- a/initrd/bin/kexec-parse-boot
+++ b/initrd/bin/kexec-parse-boot
@@ -2,7 +2,7 @@
 set -e -o pipefail
 . /etc/functions
 
-TRACE "Under /bin/kexec-parse-boot"
+TRACE_FUNC
 
 bootdir="$1"
 file="$2"

--- a/initrd/bin/kexec-save-default
+++ b/initrd/bin/kexec-save-default
@@ -4,7 +4,7 @@ set -e -o pipefail
 . /tmp/config
 . /etc/functions
 
-TRACE "Under /bin/kexec-save-default"
+TRACE_FUNC
 
 while getopts "b:d:p:i:" arg; do
 	case $arg in
@@ -71,7 +71,7 @@ fi
 
 #Reusable function when user wants to define new TPM DUK for lvms/disks
 prompt_for_existing_encrypted_lvms_or_disks() {
-	TRACE "Under kexec-save-default:prompt_for_existing_encrypted_lvms_or_disks"
+	TRACE_FUNC
 	DEBUG "num_lvm: $num_lvm, lvm_suggest: $lvm_suggest, num_devices: $num_devices, devices_suggest: $devices_suggest"
 
 	# Create an associative array to store the suggested LVMs and their paths

--- a/initrd/bin/kexec-save-key
+++ b/initrd/bin/kexec-save-key
@@ -3,7 +3,7 @@
 
 . /etc/functions
 
-TRACE "kexec-save-key: start"
+TRACE_FUNC
 set -e -o pipefail
 . /etc/functions
 

--- a/initrd/bin/kexec-seal-key
+++ b/initrd/bin/kexec-seal-key
@@ -14,7 +14,7 @@ RECOVERY_KEY="/tmp/secret/recovery.key"
 . /etc/functions
 . /tmp/config
 
-TRACE "Under kexec-seal-key"
+TRACE_FUNC
 
 paramsdir=$1
 if [ -z "$paramsdir" ]; then

--- a/initrd/bin/kexec-select-boot
+++ b/initrd/bin/kexec-select-boot
@@ -4,7 +4,7 @@ set -e -o pipefail
 . /tmp/config
 . /etc/functions
 
-TRACE "Under /bin/kexec-select-boot"
+TRACE_FUNC
 
 add=""
 remove=""

--- a/initrd/bin/kexec-sign-config
+++ b/initrd/bin/kexec-sign-config
@@ -4,7 +4,7 @@ set -e -o pipefail
 . /tmp/config
 . /etc/functions
 
-TRACE "Under /bin/kexec-sign-config"
+TRACE_FUNC
 
 rollback="n"
 update="n"

--- a/initrd/bin/kexec-unseal-key
+++ b/initrd/bin/kexec-unseal-key
@@ -10,7 +10,7 @@ TPM_SIZE=312
 
 . /etc/functions
 
-TRACE "Under kexec-unseal-key"
+TRACE_FUNC
 
 mkdir -p /tmp/secret
 

--- a/initrd/bin/key-init
+++ b/initrd/bin/key-init
@@ -2,7 +2,7 @@
 set -e -o pipefail
 . /etc/functions
 
-TRACE "Under /bin/key-init"
+TRACE_FUNC
 
 # Post processing of keys
 

--- a/initrd/bin/lock_chip
+++ b/initrd/bin/lock_chip
@@ -15,7 +15,28 @@ if [ "$CONFIG_FINALIZE_PLATFORM_LOCKING_PRESKYLAKE" = "y" ]; then
 fi
 
 if [ -n "$APM_CNT" -a -n "$FIN_CODE" ]; then
-	echo "Finalizing chipset"
+	# SMI PR0 lockdown is implemented by Intel as part of the SMM Supervisor feature.
+	# SMM Supervisor is a software component that runs in SMM and acts as a gatekeeper
+	# for SMM access.
+	#
+	# It uses the processor’s memory protection and paging mechanisms to restrict what
+	# SMM code can read and write. SMM Supervisor marks critical pages, such as its
+	# own code, data, and page tables, as supervisor pages, which are only accessible
+	# from the most privileged level (CPL0).
+	#
+	# It also marks the rest of the SMM memory as user pages, which are accessible
+	# from any privilege level.
+	#
+	# This way, SMM Supervisor can isolate itself from other SMM code and enforce a policy
+	# that states what resources the SMI handlers (the interrupt handlers that run in SMM)
+	# require access to.
+	#
+	# SMI PR0 lockdown is enabled by setting a lock bit (FLOCKDN) in the SPI controller,
+	# which prevents further changes to the SMM memory and configuration.
+	# Once SMI PR0 lockdown is enabled, it cannot be disabled until the next system reset.
+	# This ensures that malicious code cannot tamper with the SMM Supervisor or the SMI handlers
+	# after the system boots.
+	echo "Finalizing chipset Write Protection through SMI PR0 lockdown call"
 	io386 -o b -b x $APM_CNT $FIN_CODE
 else
 	echo "NOT Finalizing chipset"

--- a/initrd/bin/media-scan
+++ b/initrd/bin/media-scan
@@ -5,7 +5,7 @@ set -e -o pipefail
 . /etc/gui_functions
 . /tmp/config
 
-TRACE "Under /bin/media-scan"
+TRACE_FUNC
 
 #Booting from external media should be authenticated if supported
 gpg_auth || die "GPG authentication failed"

--- a/initrd/bin/mount-usb
+++ b/initrd/bin/mount-usb
@@ -3,7 +3,7 @@
 . /etc/functions
 . /etc/luks-functions
 
-TRACE "Under /bin/mount-usb"
+TRACE_FUNC
 
 function usage() {
   cat <<USAGE_END

--- a/initrd/bin/network-init-recovery
+++ b/initrd/bin/network-init-recovery
@@ -2,7 +2,7 @@
 
 . /etc/functions
 
-TRACE "Under /bin/network-init-recovery"
+TRACE_FUNC
 
 # bring up the ethernet; maybe should do DHCP?
 ifconfig lo 127.0.0.1

--- a/initrd/bin/oem-factory-reset
+++ b/initrd/bin/oem-factory-reset
@@ -8,7 +8,7 @@ set -o pipefail
 . /etc/luks-functions
 . /tmp/config
 
-TRACE "Under /bin/oem-factory-reset"
+TRACE_FUNC
 
 # use TERM to exit on error
 trap "exit 1" TERM
@@ -74,7 +74,7 @@ whiptail_error_die() {
 }
 
 mount_boot() {
-    TRACE "Under oem-factory-reset:mount_boot"
+    TRACE_FUNC
     # Mount local disk if it is not already mounted.
     # Added so that 'o' can be typed early at boot to enter directly into OEM Factory Reset
     if ! grep -q /boot /proc/mounts; then
@@ -89,7 +89,7 @@ mount_boot() {
 #This key will be used to sign 3 subkeys: encryption, authentication and signing
 #The master key and subkeys will be copied to backup, and the subkeys moved from memory keyring to the smartcard
 generate_inmemory_RSA_master_and_subkeys() {
-    TRACE "Under oem-factory-reset:generate_inmemory_RSA_master_and_subkeys"
+    TRACE_FUNC
     echo "Generating GPG key material in memory:"
 
     echo "Generating GPG RSA ${RSA_KEY_LENGTH} bits master key..."
@@ -187,7 +187,7 @@ generate_inmemory_RSA_master_and_subkeys() {
 #This key will be used to sign 3 subkeys: encryption, authentication and signing
 #The master key and subkeys will be copied to backup, and the subkeys moved from memory keyring to the smartcard
 generate_inmemory_p256_master_and_subkeys() {
-    TRACE "Under oem-factory-reset:generate_inmemory_p256_master_and_subkeys"
+    TRACE_FUNC
 
     echo "Generating GPG p256 bits master key..."
     {
@@ -266,7 +266,7 @@ generate_inmemory_p256_master_and_subkeys() {
 # The master key was already used to sign the subkeys, so it is not needed anymore
 # Delete the master key from the keyring once key to card is done (already backed up on LUKS private partition)
 keytocard_subkeys_to_smartcard() {
-    TRACE "Under oem-factory-reset:keytocard_subkeys_to_smartcard"
+    TRACE_FUNC
 
     #make sure usb ready and USB Security Dongle ready to communicate with
     enable_usb
@@ -304,12 +304,12 @@ keytocard_subkeys_to_smartcard() {
         whiptail_error_die "GPG Key moving subkeys to smartcard failed!\n\n$ERROR"
     fi
 
-    TRACE "oem-factory-reset:keytocard_subkeys_to_smartcard done"
+    TRACE_FUNC
 }
 
 #Whiptail prompt to insert to be wiped thumb drive
 prompt_insert_to_be_wiped_thumb_drive() {
-    TRACE "Under oem-factory-reset:prompt_insert_to_be_wiped_thumb_drive"
+    TRACE_FUNC
     #Whiptail warning about having only desired to be wiped thumb drive inserted
     whiptail $BG_COLOR_WARNING --title 'WARNING: Please insert the thumb drive to be wiped' \
         --msgbox "The thumb drive will be WIPED next.\n\nPlease connect only the thumb drive to be wiped and disconnect others." 0 80 ||
@@ -318,7 +318,7 @@ prompt_insert_to_be_wiped_thumb_drive() {
 
 #export master key and subkeys to thumbdrive's private LUKS contained partition
 export_master_key_subkeys_and_revocation_key_to_private_LUKS_container() {
-    TRACE "Under oem-factory-reset:export_master_key_subkeys_and_revocation_key_to_private_LUKS_container"
+    TRACE_FUNC
 
     #Sanity check on passed arguments
     while [ $# -gt 0 ]; do
@@ -363,12 +363,12 @@ export_master_key_subkeys_and_revocation_key_to_private_LUKS_container() {
     #Unmount private LUKS container's mount point
     umount "$mountpoint" || die "Error unmounting private LUKS container's mount point"
 
-    TRACE "oem-factory-reset:export_master_key_subkeys_and_revocation_key_to_private_LUKS_container done"
+    TRACE_FUNC
 }
 
 #Export public key to thumb drive's public partition
 export_public_key_to_thumbdrive_public_partition() {
-    TRACE "Under oem-factory-reset:export_public_key_to_thumbdrive_public_partition"
+    TRACE_FUNC
 
     #Sanity check on passed arguments
     while [ $# -gt 0 ]; do
@@ -399,7 +399,7 @@ export_public_key_to_thumbdrive_public_partition() {
     gpg --export --armor "${GPG_USER_MAIL}" >"$mountpoint"/pubkey.asc || die "Error exporting public key to thumb drive's public partition"
     umount "$mountpoint" || die "Error unmounting thumb drive's public partition"
 
-    TRACE "oem-factory-reset:export_public_key_to_thumbdrive_public_partition done"
+    TRACE_FUNC
 }
 
 # Select thumb drive and LUKS container size for GPG key export
@@ -407,7 +407,7 @@ export_public_key_to_thumbdrive_public_partition() {
 # - thumb_drive
 # - thumb_drive_luks_percent
 select_thumb_drive_for_key_material() {
-    TRACE "Under oem-factory-reset:wipe_thumb_drive_and_copy_gpg_key_material"
+    TRACE_FUNC
 
     #enable usb storage
     enable_usb
@@ -459,7 +459,7 @@ select_thumb_drive_for_key_material() {
 # $1 - thumb drive block device
 # $2 - LUKS container percentage [1-99]
 wipe_thumb_drive_and_copy_gpg_key_material() {
-    TRACE "Under oem-factory-reset:wipe_thumb_drive_and_copy_gpg_key_material"
+    TRACE_FUNC
 
     local thumb_drive thumb_drive_luks_percent
     thumb_drive="$1"
@@ -472,11 +472,11 @@ wipe_thumb_drive_and_copy_gpg_key_material() {
     #Export public key to thumb drive's public partition
     export_public_key_to_thumbdrive_public_partition --mode rw --device "$thumb_drive"2 --mountpoint /media
 
-    TRACE "Under oem-factory-reset:wipe_thumb_drive_and_copy_gpg_key_material done"
+    TRACE_FUNC
 }
 
 gpg_key_factory_reset() {
-    TRACE "Under oem-factory-reset:gpg_key_factory_reset"
+    TRACE_FUNC
 
     #enable usb storage
     enable_usb
@@ -560,11 +560,11 @@ gpg_key_factory_reset() {
         whiptail_error_die "Unknown GPG_ALGO: $GPG_ALGO"
     fi
 
-    TRACE "oem-factory-reset:gpg_key_factory_reset done"
+    TRACE_FUNC
 }
 
 generate_OEM_gpg_keys() {
-    TRACE "Under oem-factory-reset:generate_OEM_gpg_keys"
+    TRACE_FUNC
 
     #This function simply generates subkeys in smartcard following smarcard config from gpg_key_factory_reset
     echo "Generating GPG keys in USB Security Dongle's smartcard..."
@@ -586,11 +586,11 @@ generate_OEM_gpg_keys() {
         whiptail_error_die "GPG Key automatic keygen failed!\n\n$ERROR"
     fi
 
-    TRACE "oem-factory-reset:generate_OEM_gpg_keys done"
+    TRACE_FUNC
 }
 
 gpg_key_change_pin() {
-    TRACE "Under oem-factory-reset:gpg_key_change_pin"
+    TRACE_FUNC
     DEBUG "Changing GPG key PIN"
     # 1 = user PIN, 3 = admin PIN
     PIN_TYPE=$1
@@ -613,11 +613,11 @@ gpg_key_change_pin() {
         whiptail_error_die "GPG Key PIN change failed!\n\n$ERROR"
     fi
 
-    TRACE "oem-factory-reset:gpg_key_change_pin done"
+    TRACE_FUNC
 }
 
 generate_checksums() {
-    TRACE "Under oem-factory-reset:generate_checksums"
+    TRACE_FUNC
 
     # ensure /boot mounted
     if ! grep -q /boot /proc/mounts; then
@@ -711,11 +711,11 @@ generate_checksums() {
         whiptail_error_die "Error signing kexec boot files:\n\n$ERROR"
     fi
 
-    TRACE "oem-factory-reset:generate_checksums done"
+    TRACE_FUNC
 }
 
 set_default_boot_option() {
-    TRACE "Under oem-factory-reset:set_default_boot_option"
+    TRACE_FUNC
 
     option_file="/tmp/kexec_options.txt"
     tmp_menu_file="/tmp/kexec/kexec_menu.txt"
@@ -758,11 +758,11 @@ set_default_boot_option() {
         xargs sha256sum >$hash_file 2>/dev/null) ||
         whiptail_error_die "Failed to create hashes of boot files"
 
-    TRACE "oem-factory-reset:set_default_boot_option done"
+    TRACE_FUNC
 }
 
 report_integrity_measurements() {
-    TRACE "Under oem-factory-reset:report_integrity_measurements"
+    TRACE_FUNC
 
     #check for GPG key in keyring
     GPG_KEY_COUNT=$(gpg -k 2>/dev/null | wc -l)
@@ -818,11 +818,11 @@ report_integrity_measurements() {
         whiptail $MAIN_MENU_BG_COLOR --title "Measured Integrity Report" --msgbox "$date\nTOTP: $TOTP | HOTP: $HOTP\n/BOOT INTEGRITY: $HASH\n\nPress OK to continue or Ctrl+Alt+Delete to reboot" 0 80
     fi
 
-    TRACE "oem-factory-reset:report_integrity_measurements done"
+    TRACE_FUNC
 }
 
 usb_security_token_capabilities_check() {
-    TRACE "Under /bin/oem-factory-reset:usb_security_token_capabilities_check"
+    TRACE_FUNC
 
     enable_usb
     # ... first set board config preference

--- a/initrd/bin/oem-system-info-xx30
+++ b/initrd/bin/oem-system-info-xx30
@@ -9,7 +9,7 @@ export BG_COLOR_MAIN_MENU=""
 . /etc/luks-functions
 . /tmp/config
 
-TRACE "Under /bin/oem-system-info-xx30"
+TRACE_FUNC
 
   battery_charge="$(print_battery_charge)"
   battery_health="$(print_battery_health)"

--- a/initrd/bin/qubes-measure-luks
+++ b/initrd/bin/qubes-measure-luks
@@ -3,7 +3,7 @@
 # a PCR so that we can detect disk swap attacks.
 . /etc/functions
 
-TRACE "Under /bin/qubes-measure-luks"
+TRACE_FUNC
 DEBUG "Arguments passed to qubes-measure-luks: $@"
 
 # Measure the LUKS headers into PCR 6

--- a/initrd/bin/seal-hotpkey
+++ b/initrd/bin/seal-hotpkey
@@ -9,7 +9,7 @@ HOTP_KEY="/boot/kexec_hotp_key"
 
 mount_boot()
 {
-  TRACE "Under /bin/seal-hotpkey:mount_boot"
+  TRACE_FUNC
   # Mount local disk if it is not already mounted
   if ! grep -q /boot /proc/mounts; then
     if ! mount -o ro /boot; then
@@ -20,7 +20,7 @@ mount_boot()
   fi
 }
 
-TRACE "Under /bin/seal-hotpkey"
+TRACE_FUNC
 
 fatal_error()
 {

--- a/initrd/bin/seal-totp
+++ b/initrd/bin/seal-totp
@@ -7,7 +7,7 @@
 
 . /etc/functions
 
-TRACE "Under /bin/seal-totp"
+TRACE_FUNC
 
 TPM_NVRAM_SPACE=4d47
 

--- a/initrd/bin/setconsolefont.sh
+++ b/initrd/bin/setconsolefont.sh
@@ -3,7 +3,7 @@
 set -eo pipefail
 . /etc/functions
 
-TRACE "Under /bin/setconsolefont.sh"
+TRACE_FUNC
 
 # If the board ships setfont, and the console size is >=1600 lines tall,
 # increase the console font size.

--- a/initrd/bin/tpmr
+++ b/initrd/bin/tpmr
@@ -29,7 +29,7 @@ else
 	. /etc/config
 fi
 
-TRACE "Under /bin/tpmr"
+TRACE_FUNC
 
 # Busybox xxd lacks -r, and we get hex dumps from TPM1 commands.  This converts
 # a hex dump to binary data using sed and printf
@@ -50,7 +50,7 @@ tpm2_password_hex() {
 # Reads PCR binary data and writes to file.
 # -a: Append to file.  Default is to overwrite.
 tpm2_pcrread() {
-	TRACE "Under /bin/tpmr:tpm2_pcrread"
+	TRACE_FUNC
 	if [ "$1" = "-a" ]; then
 		APPEND=y
 		shift
@@ -68,7 +68,7 @@ tpm2_pcrread() {
 	DO_WITH_DEBUG tpm2 pcrread -Q -o >(cat >>"$file") "sha256:$index"
 }
 tpm1_pcrread() {
-	TRACE "Under /bin/tpmr:tpm1_pcrread"
+	TRACE_FUNC
 	if [ "$1" = "-a" ]; then
 		APPEND=y
 		shift
@@ -193,7 +193,7 @@ $0 ~ pcr {
 # hashes and/or files extended to given PCR after firmware. Resulting PCR value
 # is returned in binary form.
 replay_pcr() {
-	TRACE "Under /bin/tpmr:replay_pcr"
+	TRACE_FUNC
 	if [ -z "$2" ]; then
 		echo >&2 "No PCR number passed"
 		return
@@ -229,7 +229,7 @@ replay_pcr() {
 }
 
 tpm2_extend() {
-	TRACE "Under /bin/tpmr:tpm2_extend"
+	TRACE_FUNC
 	while true; do
 		case "$1" in
 		-ix)
@@ -254,7 +254,7 @@ tpm2_extend() {
 }
 
 tpm2_counter_read() {
-	TRACE "Under /bin/tpmr:tpm2_counter_read"
+	TRACE_FUNC
 	while true; do
 		case "$1" in
 		-ix)
@@ -270,7 +270,7 @@ tpm2_counter_read() {
 }
 
 tpm2_counter_inc() {
-	TRACE "Under /bin/tpmr:tpm2_counter_inc"
+	TRACE_FUNC
 	while true; do
 		case "$1" in
 		-ix)
@@ -291,7 +291,7 @@ tpm2_counter_inc() {
 }
 
 tpm1_counter_create() {
-	TRACE "Under /bin/tpmr:tpm1_counter_create"
+	TRACE_FUNC
 	# tpmr handles the TPM owner password (from cache or prompt), but all
 	# other parameters for TPM1 are passed directly, and TPM2 mimics the
 	# TPM1 interface.
@@ -304,7 +304,7 @@ tpm1_counter_create() {
 }
 
 tpm2_counter_create() {
-	TRACE "Under /bin/tpmr:tpm2_counter_create"
+	TRACE_FUNC
 	while true; do
 		case "$1" in
 		-pwdc)
@@ -333,7 +333,7 @@ tpm2_counter_create() {
 }
 
 tpm2_startsession() {
-	TRACE "Under /bin/tpmr:tpm2_startsession"
+	TRACE_FUNC
 	mkdir -p "$SECRET_DIR"
 	tpm2 flushcontext -Q \
 		--transient-object ||
@@ -356,7 +356,7 @@ tpm2_startsession() {
 # session file.  E.g.:
 #   at_exit cleanup_session "$SESSION_FILE"
 cleanup_session() {
-	TRACE "Under /bin/tpmr:cleanup_session"
+	TRACE_FUNC
 	session_file="$1"
 	if [ -f "$session_file" ]; then
 		DEBUG "Clean up session: $session_file"
@@ -372,7 +372,7 @@ cleanup_session() {
 # at_exit, e.g.:
 #   at_exit cleanup_shred "$FILE"
 cleanup_shred() {
-	TRACE "Under /bin/tpmr:cleanup_shred"
+	TRACE_FUNC
 	shred -n 10 -z -u "$1" 2>/dev/null || true
 }
 
@@ -408,7 +408,7 @@ tpm1_destroy() {
 # provided - TPM2 allows the TPM to fall back to current PCR values, but it is
 # not required to support this.
 tpm2_seal() {
-	TRACE "Under /bin/tpmr:tpm2_seal"
+	TRACE_FUNC
 	file="$1" #$KEY_FILE
 	index="$2"
 	pcrl="$3" #0,1,2,3,4,5,6,7 (does not include algorithm prefix)
@@ -481,7 +481,7 @@ tpm2_seal() {
 		}
 }
 tpm1_seal() {
-	TRACE "Under /bin/tpmr:tpm1_seal"
+	TRACE_FUNC
 	file="$1"
 	index="$2"
 	pcrl="$3" #0,1,2,3,4,5,6,7 (does not include algorithm prefix)
@@ -549,7 +549,7 @@ tpm1_seal() {
 # password must be provided if one was used to seal (and cannot be provided if
 # no password was used to seal).
 tpm2_unseal() {
-	TRACE "Under /bin/tpmr:tpm2_unseal"
+	TRACE_FUNC
 	index="$1"
 	pcrl="$2" #0,1,2,3,4,5,6,7 (does not include algorithm prefix)
 	sealed_size="$3"
@@ -594,7 +594,7 @@ tpm2_unseal() {
 		-S "$ENC_SESSION_FILE" >"$file"
 }
 tpm1_unseal() {
-	TRACE "Under /bin/tpmr:tpm1_unseal"
+	TRACE_FUNC
 	index="$1"
 	pcrl="$2"
 	sealed_size="$3"
@@ -629,7 +629,7 @@ tpm1_unseal() {
 }
 
 tpm2_reset() {
-	TRACE "Under /bin/tpmr:tpm2_reset"
+	TRACE_FUNC
 	tpm_owner_password="$1"
 	mkdir -p "$SECRET_DIR"
 	# output TPM Owner Password to a file to be reused in this boot session until recovery shell/reboot
@@ -678,7 +678,7 @@ tpm2_reset() {
 		"hex:$(dd if=/dev/urandom bs=32 count=1 status=none | xxd -p | tr -d ' \n')"
 }
 tpm1_reset() {
-	TRACE "Under /bin/tpmr:tpm1_reset"
+	TRACE_FUNC
 	tpm_owner_password="$1"
 	mkdir -p "$SECRET_DIR"
 	# output tpm_owner_password to a file to be reused in this boot session until recovery shell/reboot
@@ -700,7 +700,7 @@ tpm1_reset() {
 
 # Perform final cleanup before boot and lock the platform heirarchy.
 tpm2_kexec_finalize() {
-	TRACE "Under /bin/tpmr:tpm2_kexec_finalize"
+	TRACE_FUNC
 
 	# Flush sessions and transient objects
 	tpm2 flushcontext -Q --transient-object ||
@@ -720,7 +720,7 @@ tpm2_kexec_finalize() {
 }
 
 tpm2_shutdown() {
-	TRACE "Under /bin/tpmr:tpm2_shutdown"
+	TRACE_FUNC
 
 	# Prepare for shutdown.
 	# This is a "clear" shutdown (do not preserve runtime state) since we

--- a/initrd/bin/unpack_initramfs.sh
+++ b/initrd/bin/unpack_initramfs.sh
@@ -3,7 +3,7 @@ set -e -o pipefail
 
 . /etc/functions
 
-TRACE "Under unpack_initramfs.sh"
+TRACE_FUNC
 # Unpack a Linux initramfs archive.
 #
 # In general, the initramfs archive is one or more cpio archives, optionally
@@ -31,7 +31,7 @@ CPIO_ARGS=("$@")
 
 # Consume zero bytes, the first nonzero byte read (if any) is repeated on stdout
 consume_zeros() {
-    TRACE "Under unpack_initramfs.sh:consume_zeros"
+    TRACE_FUNC
     next_byte='00'
     while [ "$next_byte" = "00" ]; do
         # if we reach EOF, next_byte becomes empty (dd does not fail)
@@ -44,13 +44,13 @@ consume_zeros() {
 }
 
 unpack_cpio() {
-    TRACE "Under unpack_initramfs.sh:unpack_cpio"
+    TRACE_FUNC
     (cd "$dest_dir"; cpio -i "${CPIO_ARGS[@]}" 2>/dev/null)
 }
 
 # unpack the first segment of an archive, then write the rest to another file
 unpack_first_segment() {
-    TRACE "Under unpack_initramfs.sh:unpack_first_segment"
+    TRACE_FUNC
     unpack_archive="$1"
     dest_dir="$2"
     rest_archive="$3"

--- a/initrd/bin/unseal-hotp
+++ b/initrd/bin/unseal-hotp
@@ -8,7 +8,7 @@ HOTP_COUNTER="/boot/kexec_hotp_counter"
 
 mount_boot_or_die()
 {
-  TRACE "Under /bin/unseal-hotp:mount_boot_or_die"
+  TRACE_FUNC
   # Mount local disk if it is not already mounted
   if ! grep -q /boot /proc/mounts ; then
     mount -o ro /boot \
@@ -16,7 +16,7 @@ mount_boot_or_die()
   fi
 }
 
-TRACE "Under /bin/unseal-hotp"
+TRACE_FUNC
 
 # Store counter in file instead of TPM for now, as it conflicts with Heads
 # config TPM counter as TPM 1.2 can only increment one counter between reboots

--- a/initrd/bin/unseal-totp
+++ b/initrd/bin/unseal-totp
@@ -5,7 +5,7 @@
 
 TOTP_SECRET="/tmp/secret/totp.key"
 
-TRACE "Under /bin/unseal-totp"
+TRACE_FUNC
 
 if [ "$CONFIG_TPM" = "y" ]; then
 	tpmr unseal 4d47 0,1,2,3,4,7 312 "$TOTP_SECRET" ||

--- a/initrd/bin/usb-init
+++ b/initrd/bin/usb-init
@@ -4,7 +4,7 @@
 . /etc/functions
 . /tmp/config
 
-TRACE "Under /bin/usb-init"
+TRACE_FUNC
 
 if [ "$CONFIG_TPM" = "y" ]; then
 	# Extend PCR4 as soon as possible

--- a/initrd/bin/wget-measure.sh
+++ b/initrd/bin/wget-measure.sh
@@ -3,7 +3,7 @@
 . /etc/functions
 
 die() {
-	TRACE "Under /bin/wget-measure.sh:die"
+	TRACE_FUNC
         echo >&2 "$@"
         exit 1
 }

--- a/initrd/etc/functions
+++ b/initrd/etc/functions
@@ -64,7 +64,7 @@ pcrs() {
 }
 
 confirm_totp() {
-	TRACE "Under /etc/functions:confirm_totp"
+	TRACE_FUNC
 	prompt="$1"
 	last_half=X
 	unset totp_confirm
@@ -103,7 +103,7 @@ confirm_totp() {
 }
 
 reseal_tpm_disk_decryption_key() {
-	TRACE "Under /etc/functions:reseal_tpm_disk_decryption_key"
+	TRACE_FUNC
 	#For robustness, exit early if LUKS TPM Disk Unlock Key is prohibited in board configs
 	if [ "$CONFIG_TPM_DISK_UNLOCK_KEY" == "n" ]; then
 		DEBUG "LUKS TPM Disk Unlock Key is prohibited in board configs"
@@ -140,7 +140,7 @@ reseal_tpm_disk_decryption_key() {
 # be detected.  If USB storage was already enabled, no wait occurs, this would
 # have happened already when USB storage was enabled.
 enable_usb_storage() {
-	TRACE "Under /etc/functions:enable_usb_storage"
+	TRACE_FUNC
 	if ! lsmod | grep -q usb_storage; then
 		timeout=0
 		echo "Scanning for USB storage devices..."
@@ -155,7 +155,7 @@ enable_usb_storage() {
 }
 
 list_usb_storage() {
-	TRACE "Under /etc/functions:list_usb_storage"
+	TRACE_FUNC
 	# List all USB storage devices, including partitions unless we received argument stating we want drives only
 	# The output is a list of device names, one per line.
 
@@ -216,7 +216,7 @@ list_usb_storage() {
 # Tools should optionally accept a TPM password on the command line, since some flows need 
 # it multiple times and only one prompt is ideal.
 prompt_tpm_owner_password() {
-	TRACE "Under /etc/functions:prompt_tpm_owner_password"
+	TRACE_FUNC
 
 	if [ -s /tmp/secret/tpm_owner_password ]; then
 		DEBUG "/tmp/secret/tpm_owner_password already cached in file. Reusing"
@@ -238,7 +238,7 @@ prompt_tpm_owner_password() {
 # The password must be 1-32 characters and must be entered twice,
 # the script will loop until this is met.
 prompt_new_owner_password() {
-	TRACE "Under /etc/functions:prompt_new_owner_password"
+	TRACE_FUNC
 	local tpm_owner_password2
 	tpm_owner_password=1
 	tpm_owner_password2=2
@@ -262,7 +262,7 @@ prompt_new_owner_password() {
 }
 
 check_tpm_counter() {
-	TRACE "Under /etc/functions:check_tpm_counter"
+	TRACE_FUNC
 	
 	LABEL=${2:-3135106223}
 	tpm_password="$3"
@@ -286,20 +286,20 @@ check_tpm_counter() {
 }
 
 read_tpm_counter() {
-	TRACE "Under /etc/functions:read_tpm_counter"
+	TRACE_FUNC
 	tpmr counter_read -ix "$1" | tee "/tmp/counter-$1" ||
 		die "Counter read failed"
 }
 
 increment_tpm_counter() {
-	TRACE "Under /etc/functions:increment_tpm_counter"
+	TRACE_FUNC
 	tpmr counter_increment -ix "$1" -pwdc '' |
 		tee /tmp/counter-$1 ||
 		die "TPM counter increment failed for rollback prevention. Please reset the TPM"
 }
 
 check_config() {
-	TRACE "Under /etc/functions:check_config"
+	TRACE_FUNC
 	if [ ! -d /tmp/kexec ]; then
 		mkdir /tmp/kexec ||
 			die 'Failed to make kexec tmp dir'
@@ -340,7 +340,7 @@ replace_rom_file() {
 }
 
 replace_config() {
-	TRACE "Under /etc/functions:replace_config"
+	TRACE_FUNC
 	CONFIG_FILE=$1
 	CONFIG_OPTION=$2
 	NEW_SETTING=$3
@@ -373,7 +373,7 @@ secret_from_rom_hash() {
 }
 
 update_checksums() {
-	TRACE "Under /etc/functions:update_checksums"
+	TRACE_FUNC
 	# ensure /boot mounted
 	if ! grep -q /boot /proc/mounts; then
 		mount -o ro /boot ||
@@ -403,7 +403,7 @@ update_checksums() {
 }
 
 print_tree() {
-	TRACE "Under /etc/functions:print_tree"
+	TRACE_FUNC
 	find ./ ! -path './kexec*' -print0 | sort -z
 }
 
@@ -471,7 +471,7 @@ escape_zero() {
 # due to https://bugs.busybox.net/show_bug.cgi?id=14226. Also, certain characters
 # may be intepreted by `whiptail`, `less` et al (e.g. \n, \b, ...).
 assert_signable() {
-	TRACE "Under /etc/functions:assert_signable"
+	TRACE_FUNC
 	# ensure /boot mounted
 	if ! grep -q /boot /proc/mounts; then
 		mount -o ro /boot || die "Unable to mount /boot"
@@ -490,7 +490,7 @@ assert_signable() {
 }
 
 verify_checksums() {
-	TRACE "Under /etc/functions:verify_checksums"
+	TRACE_FUNC
 	local boot_dir="$1"
 	local gui="${2:-y}"
 
@@ -523,7 +523,7 @@ verify_checksums() {
 # detect and set /boot device
 # mount /boot if successful
 detect_boot_device() {
-	TRACE "Under /etc/functions:detect_boot_device"
+	TRACE_FUNC
 	# unmount /boot to be safe
 	cd / && umount /boot 2>/dev/null
 
@@ -570,7 +570,7 @@ detect_boot_device() {
 }
 
 scan_boot_options() {
-	TRACE "Under /etc/functions:scan_boot_options"
+	TRACE_FUNC
 	local bootdir config option_file
 	bootdir="$1"
 	config="$2"

--- a/initrd/etc/gui_functions
+++ b/initrd/etc/gui_functions
@@ -15,7 +15,7 @@ pause_automatic_boot()
 
 mount_usb()
 {
-  TRACE "under gui_functions:mount_usb"
+  TRACE_FUNC
   # Unmount any previous USB device
   if grep -q /media /proc/mounts ; then
     umount /media || die "Unable to unmount /media"
@@ -80,7 +80,7 @@ display_block_device_size() {
 # No entries in list: Displays error and exits unsuccessfully
 file_selector()
 {
-	TRACE "under gui_functions:file_selector"
+	TRACE_FUNC
 
 	local FILE_LIST MENU_MSG MENU_TITLE CHOICE_ARGS SHOW_SIZE OPTION_SIZE option_index
 
@@ -132,7 +132,7 @@ file_selector()
 
 show_system_info()
 {
-  TRACE "Under /bin/gui-init:show_system_info"
+  TRACE_FUNC
   battery_charge="$(print_battery_charge)"
   battery_health="$(print_battery_health)"
   if [ -n $battery_charge -a -n $battery_health ];then

--- a/initrd/etc/luks-functions
+++ b/initrd/etc/luks-functions
@@ -16,7 +16,7 @@ list_luks_devices() {
 
 #Whiptail prompt asking user to select ratio of device to use for LUKS container between: 25, 50, 75
 select_luks_container_size_percent() {
-	TRACE "Under /etc/luks-functions:select_luks_container_size_percent()"
+	TRACE_FUNC
 	if [ -x /bin/whiptail ]; then
 		#whiptail prompt asking user to select ratio of device to use for LUKS container between: 25, 50, 75
 		#whiptail returns the percentage of the device to use for LUKS container
@@ -56,7 +56,7 @@ select_luks_container_size_percent() {
 # Size provisioning is done by percentage of the device
 interactive_prepare_thumb_drive()
 {
-	TRACE "Under /etc/luks-functions:interactive_prepare_thumb_drive()"
+	TRACE_FUNC
 	#Refactoring: only one parameter needed to be prompted for: the passphrase for LUKS container if not coming from oem-provisioning
 	#If no passphrase was provided, ask user to select passphrase for LUKS container
 	# if no device provided as parameter, we will ask user to select device to partition
@@ -188,7 +188,7 @@ interactive_prepare_thumb_drive()
 # $2 - percent of device allocated to LUKS [1-99]
 confirm_thumb_drive_format()
 {
-	TRACE "Under /etc/luks-functions:confirm_thumb_drive_format()"
+	TRACE_FUNC
 	local DEVICE LUKS_PERCENTAGE DISK_SIZE_BYTES DISK_SIZE_DISPLAY LUKS_PERCENTAGE LUKS_SIZE_MB MSG
 
 	DEVICE="$1"
@@ -230,7 +230,7 @@ confirm_thumb_drive_format()
 # $3 - passphrase for LUKS container
 prepare_thumb_drive()
 {
-	TRACE "Under /etc/luks-functions:prepare_thumb_drive()"
+	TRACE_FUNC
 
 	local DEVICE PERCENTAGE PASSPHRASE DISK_SIZE_BYTES PERCENTAGE_MB
 	DEVICE="$1"
@@ -267,7 +267,7 @@ prepare_thumb_drive()
 
 select_luks_container()
 {
-	TRACE "Under /etc/luks-functions:select_luks_container()"
+	TRACE_FUNC
 	if [ -s /boot/kexec_key_devices.txt ]; then
 		DEBUG "Reusing known good LUKS container device from /boot/kexec_key_devices.txt"
 		DEBUG "LUKS container device: $(cut -d ' ' -f1 /boot/kexec_key_devices.txt)"
@@ -295,7 +295,7 @@ select_luks_container()
 
 test_luks_current_disk_recovery_key_passphrase()
 {
-	TRACE "Under /etc/luks-functions:test_luks_current_disk_recovery_key_passphrase()"
+	TRACE_FUNC
 	while :; do
 		select_luks_container || return 1
 		if [ -z "$luks_current_Disk_Recovery_Key_passphrase" ]; then
@@ -336,7 +336,7 @@ test_luks_current_disk_recovery_key_passphrase()
 }
 
 luks_reencrypt() {
-	TRACE "Under /etc/luks-functions:luks_reencrypt()"
+	TRACE_FUNC
 	while :; do
 		select_luks_container || return 1
                 #If the user just set a new LUKS Disk Recovery Key passphrase
@@ -382,7 +382,7 @@ luks_reencrypt() {
 
 luks_change_passphrase()
 {
-	TRACE "Under /etc/luks-functions:luks_change_passphrase()"
+	TRACE_FUNC
 	while :; do
 		select_luks_container || return 1
 		#if actual or new LUKS Disk Recovery Key is not provisioned by oem-provisioning file

--- a/initrd/sbin/insmod
+++ b/initrd/sbin/insmod
@@ -6,7 +6,7 @@
 
 . /etc/functions
 
-TRACE "Under insmod.sh"
+TRACE_FUNC
 
 MODULE="$1"; shift
 

--- a/targets/qemu.mk
+++ b/targets/qemu.mk
@@ -88,7 +88,7 @@ run: $(TPMDIR)/.manufacture $(ROOT_DISK_IMG) $(MEMORY_SIZE_FILE) $(USB_FD_IMG)
 	-qemu-system-x86_64 -drive file="$(ROOT_DISK_IMG)",if=virtio \
 		--machine q35,accel=kvm:tcg \
 		-rtc base=utc \
-		-smp "$$(nproc)" \
+		-smp 1 \
 		-vga std \
 		-m "$$(cat "$(MEMORY_SIZE_FILE)")" \
 		-serial stdio \


### PR DESCRIPTION
Exception: scripts sourcing/functions within etc/ash_functions continues to use TRACE old functions until we switch to bash completely. **This would mean getting rid of legacy boards (flash + legacy boards which do not have enough space for bash in flash boards) once and for all.**

@JonathonHall-Purism debug output under qemu-coreboot-whiptail-tpm2:
```
[    6.540069] Run /init as init process
[    6.547420]   with arguments:
[    6.555143]     /init
[    6.561831]   with environment:
[    6.567897]     HOME=/
[    6.574592]     TERM=linux
[    6.681614] [U] hello world
[    6.934029] DEBUG: Debug output enabled from board CONFIG_DEBUG_OUTPUT=y option (/etc/config)
[    6.963097] TRACE: Under init
[    7.152770] TRACE: /bin/tpmr(32): main
[    7.236947] TRACE: /bin/tpmr(336): tpm2_startsession
[    7.977410] TRACE: /bin/cbfs-init(5): main
[    8.169136] DEBUG: Extending TPM PCR 7 with /.gnupg/pubring.kbx
[    8.282191] TRACE: /bin/tpmr(32): main
[    8.347465] TRACE: /bin/tpmr(232): tpm2_extend
[    8.469490] DEBUG: tpm2 pcrread sha256:7
[    8.645978] DEBUG: Extending TPM PCR 7 with /.gnupg/trustdb.gpg
[    8.775655] TRACE: /bin/tpmr(32): main
[    8.850495] TRACE: /bin/tpmr(232): tpm2_extend
[    8.970442] DEBUG: tpm2 pcrread sha256:7
[    9.133290] TRACE: /bin/key-init(5): main
[   10.762305] TRACE: Under /etc/ash_functions:combine_configs


[   10.837907] TRACE: Under /etc/ash_functions:pause_recovery
!!! Hit enter to proceed to recovery shell !!!
[   11.095132] TRACE: /bin/setconsolefont.sh(6): main
[   11.144942] DEBUG: Board does not ship setfont, not checking console font
[   11.487358] TRACE: /bin/gui-init(642): main
[   11.529705] TRACE: /etc/functions(526): detect_boot_device
[   11.601794] exFAT-fs (vda1): invalid boot record signature
[   11.611650] exFAT-fs (vda1): failed to read boot sector
[   11.627089] exFAT-fs (vda1): failed to recognize exfat type
[   11.998994] exFAT-fs (vda1): invalid boot record signature
[   12.021188] exFAT-fs (vda1): failed to read boot sector
[   12.042971] exFAT-fs (vda1): failed to recognize exfat type
[   12.253644] EXT4-fs (vda3): INFO: recovery required on readonly filesystem
[   12.259291] EXT4-fs (vda3): write access will be enabled during recovery
[   12.315373] EXT4-fs (vda3): recovery complete
[   12.351776] EXT4-fs (vda3): mounted filesystem with ordered data mode. Opts: (null)
[   12.413448] TRACE: /bin/gui-init(316): clean_boot_check
[   12.596974] TRACE: /bin/gui-init(345): check_gpg_key
[   12.696479] TRACE: /bin/gui-init(183): update_totp
[   12.811248] TRACE: /bin/unseal-totp(8): main
[   12.920153] TRACE: /bin/tpmr(32): main
[   12.992735] TRACE: /bin/tpmr(552): tpm2_unseal
[   13.068140] DEBUG: tpm2_unseal: handle=0x81004d47 pcrl=0,1,2,3,4,7 file=/tmp/secret/totp.key pass=<empty>
[   13.775342] DEBUG: Running at_exit handlers
[   13.813627] TRACE: /bin/tpmr(359): cleanup_session
[   13.861767] DEBUG: Clean up session: /tmp/secret/unsealfile_policy.session
[   14.010902] TRACE: /bin/gui-init(252): update_hotp
[   14.054475] TRACE: /bin/gui-init(676): main
[   14.101805] TRACE: /bin/gui-init(392): show_main_menu
[   19.943130] TRACE: /bin/gui-init(425): show_options_menu
[   21.213895] TRACE: /bin/gui-init(142): prompt_update_checksums
[   21.706797] TRACE: /etc/functions(376): update_checksums
[   21.761171] EXT4-fs (vda3): re-mounted. Opts: (null)
[   21.883125] TRACE: /bin/kexec-sign-config(7): main
[   21.922304] TRACE: /etc/functions(474): assert_signable
[   22.106741] TRACE: Under /etc/ash_functions:confirm_gpg_card
[   23.332966] TRACE: Under /etc/ash_functions:enable_usb
[   23.448220] TRACE: /sbin/insmod(9): main
[   23.500964] DEBUG: Extending TPM PCR 5 with /lib/modules/ehci-hcd.ko prior of usage
[   23.618736] TRACE: /bin/tpmr(32): main
[   23.681466] TRACE: /bin/tpmr(232): tpm2_extend
[   23.804534] DEBUG: tpm2 pcrread sha256:5
[   23.918139] DEBUG: Loading /lib/modules/ehci-hcd.ko with busybox insmod
[   23.972316] ehci_hcd: USB 2.0 'Enhanced' Host Controller (EHCI) Driver
[   24.110765] TRACE: /sbin/insmod(9): main
[   24.155341] DEBUG: Extending TPM PCR 5 with /lib/modules/uhci-hcd.ko prior of usage
[   24.274247] TRACE: /bin/tpmr(32): main
[   24.342418] TRACE: /bin/tpmr(232): tpm2_extend
[   24.465985] DEBUG: tpm2 pcrread sha256:5
[   24.583042] DEBUG: Loading /lib/modules/uhci-hcd.ko with busybox insmod
[   24.625191] uhci_hcd: USB Universal Host Controller Interface driver
[   24.760612] TRACE: /sbin/insmod(9): main
[   24.802569] DEBUG: Extending TPM PCR 5 with /lib/modules/ohci-hcd.ko prior of usage
[   24.905011] TRACE: /bin/tpmr(32): main
[   24.982460] TRACE: /bin/tpmr(232): tpm2_extend
[   25.115906] DEBUG: tpm2 pcrread sha256:5
[   25.221701] DEBUG: Loading /lib/modules/ohci-hcd.ko with busybox insmod
[   25.246578] ohci_hcd: USB 1.1 'Open' Host Controller (OHCI) Driver
[   25.353995] TRACE: /sbin/insmod(9): main
[   25.417909] DEBUG: Extending TPM PCR 5 with /lib/modules/ohci-pci.ko prior of usage
[   25.526079] TRACE: /bin/tpmr(32): main
[   25.593536] TRACE: /bin/tpmr(232): tpm2_extend
[   25.694048] DEBUG: tpm2 pcrread sha256:5
[   25.814003] DEBUG: Loading /lib/modules/ohci-pci.ko with busybox insmod
[   25.834661] ohci-pci: OHCI PCI platform driver
[   25.981643] TRACE: /sbin/insmod(9): main
[   26.040694] DEBUG: Extending TPM PCR 5 with /lib/modules/ehci-pci.ko prior of usage
[   26.152286] TRACE: /bin/tpmr(32): main
[   26.222243] TRACE: /bin/tpmr(232): tpm2_extend
[   26.338544] DEBUG: tpm2 pcrread sha256:5
[   26.450655] DEBUG: Loading /lib/modules/ehci-pci.ko with busybox insmod
[   26.484998] ehci-pci: EHCI PCI platform driver
[   26.610011] TRACE: /sbin/insmod(9): main
[   26.655302] DEBUG: Extending TPM PCR 5 with /lib/modules/xhci-hcd.ko prior of usage
[   26.757444] TRACE: /bin/tpmr(32): main
[   26.830403] TRACE: /bin/tpmr(232): tpm2_extend
[   26.963254] DEBUG: tpm2 pcrread sha256:5
[   27.076660] DEBUG: Loading /lib/modules/xhci-hcd.ko with busybox insmod
[   27.234888] TRACE: /sbin/insmod(9): main
[   27.279353] DEBUG: Extending TPM PCR 5 with /lib/modules/xhci-pci.ko prior of usage
[   27.382551] TRACE: /bin/tpmr(32): main
[   27.446530] TRACE: /bin/tpmr(232): tpm2_extend
[   27.550552] DEBUG: tpm2 pcrread sha256:5
[   27.668070] DEBUG: Loading /lib/modules/xhci-pci.ko with busybox insmod
[   27.703436] xhci_hcd 0000:00:04.0: xHCI Host Controller
[   27.711571] xhci_hcd 0000:00:04.0: new USB bus registered, assigned bus number 1
[   27.730792] xhci_hcd 0000:00:04.0: hcc params 0x00087001 hci version 0x100 quirks 0x0000000000000010
[   27.757609] hub 1-0:1.0: USB hub found
[   27.765634] hub 1-0:1.0: 4 ports detected
[   27.785298] xhci_hcd 0000:00:04.0: xHCI Host Controller
[   27.793342] xhci_hcd 0000:00:04.0: new USB bus registered, assigned bus number 2
[   27.803881] xhci_hcd 0000:00:04.0: Host supports USB 3.0 SuperSpeed
[   27.816470] usb usb2: We don't know the algorithms for LPM for this host, disabling LPM.
[   27.825482] hub 2-0:1.0: USB hub found
[   27.843244] hub 2-0:1.0: 4 ports detected
[   28.133227] usb 1-1: new high-speed USB device number 2 using xhci_hcd
[   28.449026] usb 2-2: new SuperSpeed Gen 1 USB device number 2 using xhci_hcd
[   34.955926] usb 1-3: new full-speed USB device number 3 using xhci_hcd
[   60.726694] TRACE: /etc/functions(406): print_tree
[   60.844086] TRACE: /etc/functions(265): check_tpm_counter
[   60.906406] TRACE: /etc/functions(295): increment_tpm_counter
[   61.044164] TRACE: /bin/tpmr(32): main
[   61.118508] TRACE: /bin/tpmr(273): tpm2_counter_inc
[   73.665064] TRACE: /etc/functions(302): check_config
[   73.858671] TRACE: /bin/gpgv(5): main
[   74.931920] EXT4-fs (vda3): re-mounted. Opts: (null)
[   75.013043] TRACE: /bin/gui-init(676): main
[   75.045611] TRACE: /bin/gui-init(392): show_main_menu
[   78.663067] TRACE: /bin/gui-init(425): show_options_menu
[   81.880817] TRACE: /bin/gui-init(514): show_tpm_totp_hotp_options_menu
[   83.576795] TRACE: /bin/gui-init(154): generate_totp_hotp
[   83.668598] TRACE: /bin/seal-totp(10): main
[   83.737901] DEBUG: Sealing TOTP with actual state of PCR0-3
[   83.824502] TRACE: /bin/tpmr(32): main
[   83.890659] TRACE: /bin/tpmr(53): tpm2_pcrread
[   83.946076] DEBUG: tpm2 pcrread -Q -o /dev/fd/63 sha256:0
[   84.078654] TRACE: /bin/tpmr(32): main
[   84.133881] TRACE: /bin/tpmr(53): tpm2_pcrread
[   84.183347] DEBUG: tpm2 pcrread -Q -o /dev/fd/63 sha256:1
[   84.314564] TRACE: /bin/tpmr(32): main
[   84.376817] TRACE: /bin/tpmr(53): tpm2_pcrread
[   84.431945] DEBUG: tpm2 pcrread -Q -o /dev/fd/63 sha256:2
[   84.570787] TRACE: /bin/tpmr(32): main
[   84.629543] TRACE: /bin/tpmr(53): tpm2_pcrread
[   84.679447] DEBUG: tpm2 pcrread -Q -o /dev/fd/63 sha256:3
[   84.784672] DEBUG: Sealing TOTP with boot state of PCR4 (Going to recovery shell extends PCR4)
[   84.898945] TRACE: /bin/tpmr(32): main
[   84.959250] TRACE: /bin/tpmr(196): replay_pcr
[   85.131325] DEBUG: Replayed cbmem -L clean boot state of PCR=4 ALG=sha256 : 0000000000000000000000000000000000000000000000000000000000000000
[   85.202125] DEBUG: Sealing TOTP neglecting PCR5 involvement (Dynamically loaded kernel modules are not firmware integrity attestation related)
[   85.255444] DEBUG: Sealing TOTP without PCR6 involvement (LUKS header consistency is not firmware integrity attestation related)
[   85.368226] TRACE: /bin/tpmr(32): main
[   85.427480] TRACE: /bin/tpmr(53): tpm2_pcrread
[   85.488182] DEBUG: tpm2 pcrread -Q -o /dev/fd/63 sha256:7
[   85.621204] TRACE: /bin/tpmr(32): main
[   85.689714] TRACE: /bin/tpmr(411): tpm2_seal
[   85.774589] DEBUG: tpm2_seal: file=/tmp/secret/totp.key handle=0x81004d47 pcrl=0,1,2,3,4,7 pcrf=/tmp/secret/pcrf.bin pass=<empty>
[   86.487844] TRACE: /etc/functions(219): prompt_tpm_owner_password
[   91.768641] DEBUG: Caching TPM Owner Password to /tmp/secret/tpm_owner_password
[   92.022250] DEBUG: tpm2 evictcontrol -Q -C o -P <hidden> -c /tmp/secret/totp.key.seal.ctx 0x81004d47
[   92.298163] DEBUG: Running at_exit handlers
[   92.332910] TRACE: /bin/tpmr(359): cleanup_session
[   92.382875] DEBUG: Clean up session: /tmp/secret/sealfile_trial.session
[   93.361869] TRACE: /etc/functions(106): reseal_tpm_disk_decryption_key
[   93.412668] DEBUG: LUKS TPM Disk Unlock Key is allowed in board configs. Continuing
[   93.451107]  *** WARNING: LUKS TPM sealed Disk Unlock Key secret needs to be resealed alongside TOTP/HOTP secret ***
[   94.604618] TRACE: /bin/kexec-seal-key(17): main
[   94.671513] DEBUG: Devices defined for disk encryption: /dev/vda4
[   94.703612] DEBUG: No LVM volume group defined for activation
[   94.857663] DEBUG:   sha256:
[   94.880394] 0 : 0x0000000000000000000000000000000000000000000000000000000000000000
[   94.907017] 1 : 0x0000000000000000000000000000000000000000000000000000000000000000
[   94.929616] 2 : 0xBCE8AE3357C6ECFF75EB449F2F291D7B1F0271DAE7568178982D9FADF168337C
[   94.950195] 3 : 0x0000000000000000000000000000000000000000000000000000000000000000
[   94.991196] 4 : 0x0000000000000000000000000000000000000000000000000000000000000000
[   95.013357] 5 : 0x08AA3C13A45C28706BA7A2C7E49EB2A18FD19217A039A6073A934C3A41227FF6
[   95.044608] 6 : 0x0000000000000000000000000000000000000000000000000000000000000000
[   95.065679] 7 : 0x634D31CC3424251F8479D065CCC98F30F1324465B9A3253D2F29AB5AD16F6ACA
[   95.089901] 8 : 0x0000000000000000000000000000000000000000000000000000000000000000
[   95.109256] 9 : 0x0000000000000000000000000000000000000000000000000000000000000000
[   95.131092] 10: 0x0000000000000000000000000000000000000000000000000000000000000000
[   95.161797] 11: 0x0000000000000000000000000000000000000000000000000000000000000000
[   95.189728] 12: 0x0000000000000000000000000000000000000000000000000000000000000000
[   95.214481] 13: 0x0000000000000000000000000000000000000000000000000000000000000000
[   95.232833] 14: 0x0000000000000000000000000000000000000000000000000000000000000000
[   95.254648] 15: 0x0000000000000000000000000000000000000000000000000000000000000000
[   95.281101] 16: 0x0000000000000000000000000000000000000000000000000000000000000000
[   95.304832] 17: 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
[   95.323004] 18: 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
[   95.348564] 19: 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
[   95.373265] 20: 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
[   95.390203] 21: 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
[   95.417016] 22: 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
[   95.447292] 23: 0x0000000000000000000000000000000000000000000000000000000000000000
[  107.819184] DEBUG: Checking number of slots used on /dev/vda4 LUKS header
[  107.961422] DEBUG: Number of slots used on /dev/vda4 LUKS header: 2
[  107.991138] DEBUG: Slot 1 is not the only existing slot on /dev/vda4 LUKS header.
[  108.038822] DEBUG: /dev/vda4 LUKS header's slot 1 will store LUKS Disk Unlock Key that TPM will seal/unseal with LUKS TPM Disk Unlock Key passphrase
[  122.995019] TRACE: /bin/qubes-measure-luks(6): main
[  123.038047] DEBUG: Arguments passed to qubes-measure-luks: /dev/vda4
[  123.110045] DEBUG: Storing LUKS header for /dev/vda4 into /tmp/lukshdr-_dev_vda4
[  123.692813] DEBUG: Hashing LUKS headers into /tmp/luksDump.txt
[  124.319445] DEBUG: Removing /tmp/lukshdr-*
[  124.410640] DEBUG: Extending TPM PCR 6 with hash of LUKS headers from /tmp/luksDump.txt
[  124.510063] TRACE: /bin/tpmr(32): main
[  124.577444] TRACE: /bin/tpmr(232): tpm2_extend
[  124.676610] DEBUG: tpm2 pcrread sha256:6
[  124.885082] TRACE: /bin/tpmr(32): main
[  124.949203] TRACE: /bin/tpmr(53): tpm2_pcrread
[  125.014277] DEBUG: tpm2 pcrread -Q -o /dev/fd/63 sha256:0
[  125.151249] TRACE: /bin/tpmr(32): main
[  125.218128] TRACE: /bin/tpmr(53): tpm2_pcrread
[  125.276574] DEBUG: tpm2 pcrread -Q -o /dev/fd/63 sha256:1
[  125.418686] TRACE: /bin/tpmr(32): main
[  125.496553] TRACE: /bin/tpmr(53): tpm2_pcrread
[  125.555660] DEBUG: tpm2 pcrread -Q -o /dev/fd/63 sha256:2
[  125.708834] TRACE: /bin/tpmr(32): main
[  125.774034] TRACE: /bin/tpmr(53): tpm2_pcrread
[  125.836869] DEBUG: tpm2 pcrread -Q -o /dev/fd/63 sha256:3
[  126.018283] TRACE: /bin/tpmr(32): main
[  126.077607] TRACE: /bin/tpmr(196): replay_pcr
[  126.229031] DEBUG: Replayed cbmem -L clean boot state of PCR=4 ALG=sha256 : 0000000000000000000000000000000000000000000000000000000000000000
[  126.298228] DEBUG: Sealing LUKS TPM Disk Unlock Key with PCR5=0 (NO additional kernel modules are loaded per board config)...
[  126.405685] TRACE: /bin/tpmr(32): main
[  126.477244] TRACE: /bin/tpmr(196): replay_pcr
[  126.608268] DEBUG: Replayed cbmem -L clean boot state of PCR=5 ALG=sha256 : 0000000000000000000000000000000000000000000000000000000000000000
[  126.698779] DEBUG: Precomputing TPM future value for PCR6 sealing/unsealing of LUKS TPM Disk Unlock Key...
[  126.793404] TRACE: /bin/tpmr(32): main
[  126.880185] TRACE: /bin/tpmr(196): replay_pcr
[  127.129626] DEBUG: Replayed cbmem -L clean boot state of PCR=6 ALG=sha256 : 37b98f54ff190401eac0eccc83d3b796a3a6a7f9f0bb195d82dffab862d4ad0e
[  127.231723] TRACE: /bin/tpmr(32): main
[  127.294161] TRACE: /bin/tpmr(53): tpm2_pcrread
[  127.373195] DEBUG: tpm2 pcrread -Q -o /dev/fd/63 sha256:7
[  127.510013] DEBUG: tpmr seal /tmp/secret/secret.key 3 0,1,2,3,4,5,6,7 /tmp/secret/pcrf.bin 312 <hidden>
[  127.615337] TRACE: /bin/tpmr(32): main
[  127.679950] TRACE: /bin/tpmr(411): tpm2_seal
[  127.775490] DEBUG: tpm2_seal: file=/tmp/secret/secret.key handle=0x81000003 pcrl=0,1,2,3,4,5,6,7 pcrf=/tmp/secret/pcrf.bin pass=<hidden>
[  128.612834] TRACE: /etc/functions(219): prompt_tpm_owner_password
[  128.666674] DEBUG: /tmp/secret/tpm_owner_password already cached in file. Reusing
[  128.945034] DEBUG: tpm2 evictcontrol -Q -C o -P <hidden> -c /tmp/secret/secret.key.seal.ctx 0x81000003
[  129.201338] DEBUG: Running at_exit handlers
[  129.238032] TRACE: /bin/tpmr(359): cleanup_session
[  129.285486] DEBUG: Clean up session: /tmp/secret/sealfile_trial.session
[  129.425697] EXT4-fs (vda3): re-mounted. Opts: (null)
[  129.553896] EXT4-fs (vda3): re-mounted. Opts: (null)
[  129.653345]  *** WARNING: LUKS header hash changed under /boot/kexec_luks_hdr_hash.txt ***
[  130.749852] TRACE: /etc/functions(376): update_checksums
[  130.806873] EXT4-fs (vda3): re-mounted. Opts: (null)
[  130.912717] TRACE: /bin/kexec-sign-config(7): main
[  130.949801] TRACE: /etc/functions(474): assert_signable
[  131.158665] TRACE: Under /etc/ash_functions:confirm_gpg_card
[  132.509435] TRACE: Under /etc/ash_functions:enable_usb
[  147.811291] TRACE: /etc/functions(406): print_tree
[  147.932552] TRACE: /etc/functions(265): check_tpm_counter
[  148.001271] TRACE: /etc/functions(295): increment_tpm_counter
[  148.106404] TRACE: /bin/tpmr(32): main
[  148.180030] TRACE: /bin/tpmr(273): tpm2_counter_inc
[  154.859318] TRACE: /etc/functions(302): check_config
[  155.117717] TRACE: /bin/gpgv(5): main
[  156.185573] EXT4-fs (vda3): re-mounted. Opts: (null)
[  156.223792]  *** WARNING: Rebooting in 3 seconds to enable booting default boot option ***
[  160.304548] TRACE: Under /bin/reboot
```
