### PR TITLE
Improve DEBUG and DO_WITH_DEBUG output handling to also keep output of DO_WITH_DEBUG commands

### DIFF
--- a/boards/qemu-coreboot-fbwhiptail-tpm1-hotp/qemu-coreboot-fbwhiptail-tpm1-hotp.config
+++ b/boards/qemu-coreboot-fbwhiptail-tpm1-hotp/qemu-coreboot-fbwhiptail-tpm1-hotp.config
@@ -8,56 +8,83 @@ export CONFIG_COREBOOT=y
 export CONFIG_COREBOOT_VERSION=4.22.01
 export CONFIG_LINUX_VERSION=5.10.5
 
+CONFIG_COREBOOT_CONFIG=config/coreboot-qemu-tpm1.config
+CONFIG_LINUX_CONFIG=config/linux-qemu.config
+
 #Enable only one RESTRICTED/BASIC boot modes below to test them manually (we cannot inject config under QEMU (no internal flashing)
 #export CONFIG_RESTRICTED_BOOT=y
 #export CONFIG_BASIC=y
 
+#Enable HAVE_GPG_KEY_BACKUP to test GPG key backup drive (we cannot inject config under QEMU (no internal flashing))
+#export CONFIG_HAVE_GPG_KEY_BACKUP=y
+
 #Enable DEBUG output
 export CONFIG_DEBUG_OUTPUT=y
 export CONFIG_ENABLE_FUNCTION_TRACING_OUTPUT=y
+#Enable TPM2 pcap output under /tmp
+#export CONFIG_TPM2_CAPTURE_PCAP=y
 
-CONFIG_COREBOOT_CONFIG=config/coreboot-qemu-tpm1.config
-CONFIG_LINUX_CONFIG=config/linux-qemu.config
+#On-demand hardware support (modules.cpio)
+CONFIG_LINUX_USB=y
+CONFIG_LINUX_E1000=y
+#CONFIG_MOBILE_TETHERING=y
 
+
+
+#Modules packed into tools.cpio
 ifeq "$(CONFIG_UROOT)" "y"
 CONFIG_BUSYBOX=n
 else
-CONFIG_KEXEC=y
-CONFIG_QRENCODE=y
-CONFIG_TPMTOTP=y
-CONFIG_POPT=y
-CONFIG_FLASHTOOLS=y
-CONFIG_FLASHROM=y
-CONFIG_PCIUTILS=y
-CONFIG_UTIL_LINUX=y
 CONFIG_CRYPTSETUP2=y
+CONFIG_FLASHROM=y
+CONFIG_FLASHTOOLS=y
 CONFIG_GPG2=y
+CONFIG_KEXEC=y
+CONFIG_UTIL_LINUX=y
 CONFIG_LVM2=y
 CONFIG_MBEDTLS=y
-CONFIG_DROPBEAR=y
+CONFIG_PCIUTILS=y
+#Runtime tools to write to EC/MSR
+CONFIG_IOTOOLS=y
 CONFIG_MSRTOOLS=y
+#Remote attestation support
+# TPM2 requirements
+#CONFIG_TPM2_TSS=y
+#CONFIG_OPENSSL=y
+#Remote Attestation common tools
+CONFIG_POPT=y
+CONFIG_QRENCODE=y
+CONFIG_TPMTOTP=y
+#HOTP based remote attestation for supported USB Security dongle
+#With/Without TPM support
 CONFIG_HOTPKEY=y
-export CONFIG_AUTO_BOOT_TIMEOUT=5
-
-#Uncomment only one of the following block
-#Required for graphical gui-init (FBWhiptail)
+#Nitrokey Storage admin tool (deprecated)
+#CONFIG_NKSTORECLI=n
+#GUI Support
+#FBWhiptail based (Graphical):
 CONFIG_CAIRO=y
 CONFIG_FBWHIPTAIL=y
-#
 #text-based init (generic-init and gui-init)
 #CONFIG_NEWT=y
 #CONFIG_SLANG=y
-
+#Additional tools (tools.cpio):
+#SSH server (requires ethernet drivers, eg: CONFIG_LINUX_E1000E)
+CONFIG_DROPBEAR=y
 endif
 
+#Runtime on-demand additional hardware support (modules.cpio)
 export CONFIG_LINUX_USB_COMPANION_CONTROLLER=y
-CONFIG_LINUX_USB=y
-CONFIG_LINUX_E1000=y
 
-#Uncomment only one BOOTSCRIPT:
-#Whiptail-based init (text-based or FBWhiptail)
+
+#Runtime configuration
+#Automatically boot if HOTP is valid
+export CONFIG_AUTO_BOOT_TIMEOUT=5
+#TPM2 requirements
+#export CONFIG_TPM2_TOOLS=y
+#export CONFIG_PRIMARY_KEY_TYPE=ecc
+#TPM1 requirements
+export CONFIG_TPM=y
 export CONFIG_BOOTSCRIPT=/bin/gui-init
-#
 #text-based original init:
 #export CONFIG_BOOTSCRIPT=/bin/generic-init
 export CONFIG_BOOT_REQ_HASH=n
@@ -65,9 +92,6 @@ export CONFIG_BOOT_REQ_ROLLBACK=n
 export CONFIG_BOOT_RECOVERY_SERIAL="/dev/ttyS0"
 export CONFIG_BOOT_KERNEL_ADD="console=ttyS0 console=tty systemd.zram=0"
 export CONFIG_BOOT_KERNEL_REMOVE="quiet rhgb splash"
-
-export CONFIG_TPM=y
-
 export CONFIG_BOOT_DEV="/dev/vda1"
 export CONFIG_BOARD_NAME="qemu-coreboot-fbwhiptail-tpm1-hotp"
 

--- a/boards/qemu-coreboot-fbwhiptail-tpm1/qemu-coreboot-fbwhiptail-tpm1.config
+++ b/boards/qemu-coreboot-fbwhiptail-tpm1/qemu-coreboot-fbwhiptail-tpm1.config
@@ -6,6 +6,9 @@ export CONFIG_COREBOOT=y
 export CONFIG_COREBOOT_VERSION=4.22.01
 export CONFIG_LINUX_VERSION=5.10.5
 
+CONFIG_COREBOOT_CONFIG=config/coreboot-qemu-tpm2.config
+CONFIG_LINUX_CONFIG=config/linux-qemu.config
+
 #Enable only one RESTRICTED/BASIC boot modes below to test them manually (we cannot inject config under QEMU (no internal flashing)
 #export CONFIG_RESTRICTED_BOOT=y
 #export CONFIG_BASIC=y
@@ -16,48 +19,70 @@ export CONFIG_LINUX_VERSION=5.10.5
 #Enable DEBUG output
 export CONFIG_DEBUG_OUTPUT=y
 export CONFIG_ENABLE_FUNCTION_TRACING_OUTPUT=y
+#Enable TPM2 pcap output under /tmp
+#export CONFIG_TPM2_CAPTURE_PCAP=y
 
-CONFIG_COREBOOT_CONFIG=config/coreboot-qemu-tpm1.config
-CONFIG_LINUX_CONFIG=config/linux-qemu.config
+#On-demand hardware support (modules.cpio)
+CONFIG_LINUX_USB=y
+CONFIG_LINUX_E1000=y
+#CONFIG_MOBILE_TETHERING=y
 
+
+
+#Modules packed into tools.cpio
 ifeq "$(CONFIG_UROOT)" "y"
 CONFIG_BUSYBOX=n
 else
-CONFIG_KEXEC=y
-CONFIG_QRENCODE=y
-CONFIG_TPMTOTP=y
-CONFIG_POPT=y
-CONFIG_FLASHTOOLS=y
-CONFIG_FLASHROM=y
-CONFIG_PCIUTILS=y
-CONFIG_UTIL_LINUX=y
 CONFIG_CRYPTSETUP2=y
+CONFIG_FLASHROM=y
+CONFIG_FLASHTOOLS=y
 CONFIG_GPG2=y
+CONFIG_KEXEC=y
+CONFIG_UTIL_LINUX=y
 CONFIG_LVM2=y
 CONFIG_MBEDTLS=y
-CONFIG_DROPBEAR=y
+CONFIG_PCIUTILS=y
+#Runtime tools to write to EC/MSR
+CONFIG_IOTOOLS=y
 CONFIG_MSRTOOLS=y
+#Remote attestation support
+# TPM2 requirements
+#CONFIG_TPM2_TSS=y
+#CONFIG_OPENSSL=y
+#Remote Attestation common tools
+CONFIG_POPT=y
+CONFIG_QRENCODE=y
+CONFIG_TPMTOTP=y
+#HOTP based remote attestation for supported USB Security dongle
+#With/Without TPM support
 #CONFIG_HOTPKEY=y
-
-#Uncomment only one of the following block
-#Required for graphical gui-init (FBWhiptail)
+#Nitrokey Storage admin tool (deprecated)
+#CONFIG_NKSTORECLI=n
+#GUI Support
+#FBWhiptail based (Graphical):
 CONFIG_CAIRO=y
 CONFIG_FBWHIPTAIL=y
-#
 #text-based init (generic-init and gui-init)
 #CONFIG_NEWT=y
 #CONFIG_SLANG=y
-
+#Additional tools (tools.cpio):
+#SSH server (requires ethernet drivers, eg: CONFIG_LINUX_E1000E)
+CONFIG_DROPBEAR=y
 endif
 
+#Runtime on-demand additional hardware support (modules.cpio)
 export CONFIG_LINUX_USB_COMPANION_CONTROLLER=y
-CONFIG_LINUX_USB=y
-CONFIG_LINUX_E1000=y
 
-#Uncomment only one BOOTSCRIPT:
-#Whiptail-based init (text-based or FBWhiptail)
+
+#Runtime configuration
+#Automatically boot if HOTP is valid
+export CONFIG_AUTO_BOOT_TIMEOUT=5
+#TPM2 requirements
+#export CONFIG_TPM2_TOOLS=y
+#export CONFIG_PRIMARY_KEY_TYPE=ecc
+#TPM1 requirements
+export CONFIG_TPM=y
 export CONFIG_BOOTSCRIPT=/bin/gui-init
-#
 #text-based original init:
 #export CONFIG_BOOTSCRIPT=/bin/generic-init
 export CONFIG_BOOT_REQ_HASH=n
@@ -65,9 +90,6 @@ export CONFIG_BOOT_REQ_ROLLBACK=n
 export CONFIG_BOOT_RECOVERY_SERIAL="/dev/ttyS0"
 export CONFIG_BOOT_KERNEL_ADD="console=ttyS0 console=tty systemd.zram=0"
 export CONFIG_BOOT_KERNEL_REMOVE="quiet rhgb splash"
-
-export CONFIG_TPM=y
-
 export CONFIG_BOOT_DEV="/dev/vda1"
 export CONFIG_BOARD_NAME="qemu-coreboot-fbwhiptail-tpm1"
 

--- a/boards/qemu-coreboot-fbwhiptail-tpm2-hotp/qemu-coreboot-fbwhiptail-tpm2-hotp.config
+++ b/boards/qemu-coreboot-fbwhiptail-tpm2-hotp/qemu-coreboot-fbwhiptail-tpm2-hotp.config
@@ -7,9 +7,15 @@ export CONFIG_COREBOOT=y
 export CONFIG_COREBOOT_VERSION=4.22.01
 export CONFIG_LINUX_VERSION=5.10.5
 
+CONFIG_COREBOOT_CONFIG=config/coreboot-qemu-tpm2.config
+CONFIG_LINUX_CONFIG=config/linux-qemu.config
+
 #Enable only one RESTRICTED/BASIC boot modes below to test them manually (we cannot inject config under QEMU (no internal flashing)
 #export CONFIG_RESTRICTED_BOOT=y
 #export CONFIG_BASIC=y
+
+#Enable HAVE_GPG_KEY_BACKUP to test GPG key backup drive (we cannot inject config under QEMU (no internal flashing))
+#export CONFIG_HAVE_GPG_KEY_BACKUP=y
 
 #Enable DEBUG output
 export CONFIG_DEBUG_OUTPUT=y
@@ -17,48 +23,67 @@ export CONFIG_ENABLE_FUNCTION_TRACING_OUTPUT=y
 #Enable TPM2 pcap output under /tmp
 export CONFIG_TPM2_CAPTURE_PCAP=y
 
-CONFIG_COREBOOT_CONFIG=config/coreboot-qemu-tpm2.config
-CONFIG_LINUX_CONFIG=config/linux-qemu.config
+#On-demand hardware support (modules.cpio)
+CONFIG_LINUX_USB=y
+CONFIG_LINUX_E1000=y
+#CONFIG_MOBILE_TETHERING=y
 
+
+
+#Modules packed into tools.cpio
 ifeq "$(CONFIG_UROOT)" "y"
 CONFIG_BUSYBOX=n
 else
-CONFIG_KEXEC=y
-CONFIG_QRENCODE=y
-CONFIG_TPMTOTP=y
-CONFIG_POPT=y
-CONFIG_FLASHTOOLS=y
-CONFIG_FLASHROM=y
-CONFIG_PCIUTILS=y
-CONFIG_UTIL_LINUX=y
 CONFIG_CRYPTSETUP2=y
+CONFIG_FLASHROM=y
+CONFIG_FLASHTOOLS=y
 CONFIG_GPG2=y
+CONFIG_KEXEC=y
+CONFIG_UTIL_LINUX=y
 CONFIG_LVM2=y
 CONFIG_MBEDTLS=y
-CONFIG_DROPBEAR=y
+CONFIG_PCIUTILS=y
+#Runtime tools to write to EC/MSR
+CONFIG_IOTOOLS=y
 CONFIG_MSRTOOLS=y
+#Remote attestation support
+# TPM2 requirements
+CONFIG_TPM2_TSS=y
+CONFIG_OPENSSL=y
+#Remote Attestation common tools
+CONFIG_POPT=y
+CONFIG_QRENCODE=y
+CONFIG_TPMTOTP=y
+#HOTP based remote attestation for supported USB Security dongle
+#With/Without TPM support
 CONFIG_HOTPKEY=y
-export CONFIG_AUTO_BOOT_TIMEOUT=5
-
-#Uncomment only one of the following block
-#Required for graphical gui-init (FBWhiptail)
+#Nitrokey Storage admin tool (deprecated)
+#CONFIG_NKSTORECLI=n
+#GUI Support
+#FBWhiptail based (Graphical):
 CONFIG_CAIRO=y
 CONFIG_FBWHIPTAIL=y
-#
 #text-based init (generic-init and gui-init)
 #CONFIG_NEWT=y
 #CONFIG_SLANG=y
-
+#Additional tools (tools.cpio):
+#SSH server (requires ethernet drivers, eg: CONFIG_LINUX_E1000E)
+CONFIG_DROPBEAR=y
 endif
 
+#Runtime on-demand additional hardware support (modules.cpio)
 export CONFIG_LINUX_USB_COMPANION_CONTROLLER=y
-CONFIG_LINUX_USB=y
-CONFIG_LINUX_E1000=y
 
-#Uncomment only one BOOTSCRIPT:
-#Whiptail-based init (text-based or FBWhiptail)
+
+#Runtime configuration
+#Automatically boot if HOTP is valid
+export CONFIG_AUTO_BOOT_TIMEOUT=5
+#TPM2 requirements
+export CONFIG_TPM2_TOOLS=y
+export CONFIG_PRIMARY_KEY_TYPE=ecc
+#TPM1 requirements
+#export CONFIG_TPM=y
 export CONFIG_BOOTSCRIPT=/bin/gui-init
-#
 #text-based original init:
 #export CONFIG_BOOTSCRIPT=/bin/generic-init
 export CONFIG_BOOT_REQ_HASH=n
@@ -66,13 +91,6 @@ export CONFIG_BOOT_REQ_ROLLBACK=n
 export CONFIG_BOOT_RECOVERY_SERIAL="/dev/ttyS0"
 export CONFIG_BOOT_KERNEL_ADD="console=ttyS0 console=tty systemd.zram=0"
 export CONFIG_BOOT_KERNEL_REMOVE="quiet rhgb splash"
-
-#TPM2 requirements
-export CONFIG_TPM2_TOOLS=y
-export CONFIG_PRIMARY_KEY_TYPE=ecc
-CONFIG_TPM2_TSS=y
-CONFIG_OPENSSL=y
-
 export CONFIG_BOOT_DEV="/dev/vda1"
 export CONFIG_BOARD_NAME="qemu-coreboot-fbwhiptail-tpm2-hotp"
 

--- a/boards/qemu-coreboot-fbwhiptail-tpm2/qemu-coreboot-fbwhiptail-tpm2.config
+++ b/boards/qemu-coreboot-fbwhiptail-tpm2/qemu-coreboot-fbwhiptail-tpm2.config
@@ -6,6 +6,9 @@ export CONFIG_COREBOOT=y
 export CONFIG_COREBOOT_VERSION=4.22.01
 export CONFIG_LINUX_VERSION=5.10.5
 
+CONFIG_COREBOOT_CONFIG=config/coreboot-qemu-tpm2.config
+CONFIG_LINUX_CONFIG=config/linux-qemu.config
+
 #Enable only one RESTRICTED/BASIC boot modes below to test them manually (we cannot inject config under QEMU (no internal flashing)
 #export CONFIG_RESTRICTED_BOOT=y
 #export CONFIG_BASIC=y
@@ -19,47 +22,67 @@ export CONFIG_ENABLE_FUNCTION_TRACING_OUTPUT=y
 #Enable TPM2 pcap output under /tmp
 export CONFIG_TPM2_CAPTURE_PCAP=y
 
-CONFIG_COREBOOT_CONFIG=config/coreboot-qemu-tpm2.config
-CONFIG_LINUX_CONFIG=config/linux-qemu.config
+#On-demand hardware support (modules.cpio)
+CONFIG_LINUX_USB=y
+CONFIG_LINUX_E1000=y
+#CONFIG_MOBILE_TETHERING=y
 
+
+
+#Modules packed into tools.cpio
 ifeq "$(CONFIG_UROOT)" "y"
 CONFIG_BUSYBOX=n
 else
-CONFIG_KEXEC=y
-CONFIG_QRENCODE=y
-CONFIG_TPMTOTP=y
-CONFIG_POPT=y
-CONFIG_FLASHTOOLS=y
-CONFIG_FLASHROM=y
-CONFIG_PCIUTILS=y
-CONFIG_UTIL_LINUX=y
 CONFIG_CRYPTSETUP2=y
+CONFIG_FLASHROM=y
+CONFIG_FLASHTOOLS=y
 CONFIG_GPG2=y
+CONFIG_KEXEC=y
+CONFIG_UTIL_LINUX=y
 CONFIG_LVM2=y
 CONFIG_MBEDTLS=y
-CONFIG_DROPBEAR=y
+CONFIG_PCIUTILS=y
+#Runtime tools to write to EC/MSR
+CONFIG_IOTOOLS=y
 CONFIG_MSRTOOLS=y
-CONFIG_HOTPKEY=n
-
-#Uncomment only one of the following block
-#Required for graphical gui-init (FBWhiptail)
+#Remote attestation support
+# TPM2 requirements
+CONFIG_TPM2_TSS=y
+CONFIG_OPENSSL=y
+#Remote Attestation common tools
+CONFIG_POPT=y
+CONFIG_QRENCODE=y
+CONFIG_TPMTOTP=y
+#HOTP based remote attestation for supported USB Security dongle
+#With/Without TPM support
+#CONFIG_HOTPKEY=y
+#Nitrokey Storage admin tool (deprecated)
+#CONFIG_NKSTORECLI=n
+#GUI Support
+#FBWhiptail based (Graphical):
 CONFIG_CAIRO=y
 CONFIG_FBWHIPTAIL=y
-#
 #text-based init (generic-init and gui-init)
 #CONFIG_NEWT=y
 #CONFIG_SLANG=y
-
+#Additional tools (tools.cpio):
+#SSH server (requires ethernet drivers, eg: CONFIG_LINUX_E1000E)
+CONFIG_DROPBEAR=y
 endif
 
+#Runtime on-demand additional hardware support (modules.cpio)
 export CONFIG_LINUX_USB_COMPANION_CONTROLLER=y
-CONFIG_LINUX_USB=y
-CONFIG_LINUX_E1000=y
 
-#Uncomment only one BOOTSCRIPT:
-#Whiptail-based init (text-based or FBWhiptail)
+
+#Runtime configuration
+#Automatically boot if HOTP is valid
+export CONFIG_AUTO_BOOT_TIMEOUT=5
+#TPM2 requirements
+export CONFIG_TPM2_TOOLS=y
+export CONFIG_PRIMARY_KEY_TYPE=ecc
+#TPM1 requirements
+#export CONFIG_TPM=y
 export CONFIG_BOOTSCRIPT=/bin/gui-init
-#
 #text-based original init:
 #export CONFIG_BOOTSCRIPT=/bin/generic-init
 export CONFIG_BOOT_REQ_HASH=n
@@ -67,13 +90,6 @@ export CONFIG_BOOT_REQ_ROLLBACK=n
 export CONFIG_BOOT_RECOVERY_SERIAL="/dev/ttyS0"
 export CONFIG_BOOT_KERNEL_ADD="console=ttyS0 console=tty systemd.zram=0"
 export CONFIG_BOOT_KERNEL_REMOVE="quiet rhgb splash"
-
-#TPM2 requirements
-export CONFIG_TPM2_TOOLS=y
-export CONFIG_PRIMARY_KEY_TYPE=ecc
-CONFIG_TPM2_TSS=y
-CONFIG_OPENSSL=y
-
 export CONFIG_BOOT_DEV="/dev/vda1"
 export CONFIG_BOARD_NAME="qemu-coreboot-fbwhiptail-tpm2"
 

--- a/boards/qemu-coreboot-whiptail-tpm1-hotp/qemu-coreboot-whiptail-tpm1-hotp.config
+++ b/boards/qemu-coreboot-whiptail-tpm1-hotp/qemu-coreboot-whiptail-tpm1-hotp.config
@@ -8,56 +8,83 @@ export CONFIG_COREBOOT=y
 export CONFIG_COREBOOT_VERSION=4.22.01
 export CONFIG_LINUX_VERSION=5.10.5
 
+CONFIG_COREBOOT_CONFIG=config/coreboot-qemu-tpm1.config
+CONFIG_LINUX_CONFIG=config/linux-qemu.config
+
 #Enable only one RESTRICTED/BASIC boot modes below to test them manually (we cannot inject config under QEMU (no internal flashing)
 #export CONFIG_RESTRICTED_BOOT=y
 #export CONFIG_BASIC=y
 
+#Enable HAVE_GPG_KEY_BACKUP to test GPG key backup drive (we cannot inject config under QEMU (no internal flashing))
+#export CONFIG_HAVE_GPG_KEY_BACKUP=y
+
 #Enable DEBUG output
 export CONFIG_DEBUG_OUTPUT=y
 export CONFIG_ENABLE_FUNCTION_TRACING_OUTPUT=y
+#Enable TPM2 pcap output under /tmp
+#export CONFIG_TPM2_CAPTURE_PCAP=y
 
-CONFIG_COREBOOT_CONFIG=config/coreboot-qemu-tpm1.config
-CONFIG_LINUX_CONFIG=config/linux-qemu.config
+#On-demand hardware support (modules.cpio)
+CONFIG_LINUX_USB=y
+CONFIG_LINUX_E1000=y
+#CONFIG_MOBILE_TETHERING=y
 
+
+
+#Modules packed into tools.cpio
 ifeq "$(CONFIG_UROOT)" "y"
 CONFIG_BUSYBOX=n
 else
-CONFIG_KEXEC=y
-CONFIG_QRENCODE=y
-CONFIG_TPMTOTP=y
-CONFIG_POPT=y
-CONFIG_FLASHTOOLS=y
-CONFIG_FLASHROM=y
-CONFIG_PCIUTILS=y
-CONFIG_UTIL_LINUX=y
 CONFIG_CRYPTSETUP2=y
+CONFIG_FLASHROM=y
+CONFIG_FLASHTOOLS=y
 CONFIG_GPG2=y
+CONFIG_KEXEC=y
+CONFIG_UTIL_LINUX=y
 CONFIG_LVM2=y
 CONFIG_MBEDTLS=y
-CONFIG_DROPBEAR=y
+CONFIG_PCIUTILS=y
+#Runtime tools to write to EC/MSR
+CONFIG_IOTOOLS=y
 CONFIG_MSRTOOLS=y
+#Remote attestation support
+# TPM2 requirements
+#CONFIG_TPM2_TSS=y
+#CONFIG_OPENSSL=y
+#Remote Attestation common tools
+CONFIG_POPT=y
+CONFIG_QRENCODE=y
+CONFIG_TPMTOTP=y
+#HOTP based remote attestation for supported USB Security dongle
+#With/Without TPM support
 CONFIG_HOTPKEY=y
-export CONFIG_AUTO_BOOT_TIMEOUT=5
-
-#Uncomment only one of the following block
-#Required for graphical gui-init (FBWhiptail)
+#Nitrokey Storage admin tool (deprecated)
+#CONFIG_NKSTORECLI=n
+#GUI Support
+#FBWhiptail based (Graphical):
 #CONFIG_CAIRO=y
 #CONFIG_FBWHIPTAIL=y
-#
 #text-based init (generic-init and gui-init)
 CONFIG_NEWT=y
 CONFIG_SLANG=y
-
+#Additional tools (tools.cpio):
+#SSH server (requires ethernet drivers, eg: CONFIG_LINUX_E1000E)
+CONFIG_DROPBEAR=y
 endif
 
+#Runtime on-demand additional hardware support (modules.cpio)
 export CONFIG_LINUX_USB_COMPANION_CONTROLLER=y
-CONFIG_LINUX_USB=y
-CONFIG_LINUX_E1000=y
 
-#Uncomment only one BOOTSCRIPT:
-#Whiptail-based init (text-based or FBWhiptail)
+
+#Runtime configuration
+#Automatically boot if HOTP is valid
+export CONFIG_AUTO_BOOT_TIMEOUT=5
+#TPM2 requirements
+#export CONFIG_TPM2_TOOLS=y
+#export CONFIG_PRIMARY_KEY_TYPE=ecc
+#TPM1 requirements
+export CONFIG_TPM=y
 export CONFIG_BOOTSCRIPT=/bin/gui-init
-#
 #text-based original init:
 #export CONFIG_BOOTSCRIPT=/bin/generic-init
 export CONFIG_BOOT_REQ_HASH=n
@@ -65,9 +92,6 @@ export CONFIG_BOOT_REQ_ROLLBACK=n
 export CONFIG_BOOT_RECOVERY_SERIAL="/dev/ttyS0"
 export CONFIG_BOOT_KERNEL_ADD="console=ttyS0 console=tty systemd.zram=0"
 export CONFIG_BOOT_KERNEL_REMOVE="quiet rhgb splash"
-
-export CONFIG_TPM=y
-
 export CONFIG_BOOT_DEV="/dev/vda1"
 export CONFIG_BOARD_NAME="qemu-coreboot-whiptail-tpm1-hotp"
 

--- a/boards/qemu-coreboot-whiptail-tpm1/qemu-coreboot-whiptail-tpm1.config
+++ b/boards/qemu-coreboot-whiptail-tpm1/qemu-coreboot-whiptail-tpm1.config
@@ -6,7 +6,10 @@ export CONFIG_COREBOOT=y
 export CONFIG_COREBOOT_VERSION=4.22.01
 export CONFIG_LINUX_VERSION=5.10.5
 
-#Enable only one RESTRICTED/BASIC boot modes below to test them manually (we cannot inject config under QEMU (no internal flashing))
+CONFIG_COREBOOT_CONFIG=config/coreboot-qemu-tpm1.config
+CONFIG_LINUX_CONFIG=config/linux-qemu.config
+
+#Enable only one RESTRICTED/BASIC boot modes below to test them manually (we cannot inject config under QEMU (no internal flashing)
 #export CONFIG_RESTRICTED_BOOT=y
 #export CONFIG_BASIC=y
 
@@ -16,48 +19,70 @@ export CONFIG_LINUX_VERSION=5.10.5
 #Enable DEBUG output
 export CONFIG_DEBUG_OUTPUT=y
 export CONFIG_ENABLE_FUNCTION_TRACING_OUTPUT=y
+#Enable TPM2 pcap output under /tmp
+#export CONFIG_TPM2_CAPTURE_PCAP=y
 
-CONFIG_COREBOOT_CONFIG=config/coreboot-qemu-tpm1.config
-CONFIG_LINUX_CONFIG=config/linux-qemu.config
+#On-demand hardware support (modules.cpio)
+CONFIG_LINUX_USB=y
+CONFIG_LINUX_E1000=y
+#CONFIG_MOBILE_TETHERING=y
 
+
+
+#Modules packed into tools.cpio
 ifeq "$(CONFIG_UROOT)" "y"
 CONFIG_BUSYBOX=n
 else
-CONFIG_KEXEC=y
-CONFIG_QRENCODE=y
-CONFIG_TPMTOTP=y
-CONFIG_POPT=y
-CONFIG_FLASHTOOLS=y
-CONFIG_FLASHROM=y
-CONFIG_PCIUTILS=y
-CONFIG_UTIL_LINUX=y
 CONFIG_CRYPTSETUP2=y
+CONFIG_FLASHROM=y
+CONFIG_FLASHTOOLS=y
 CONFIG_GPG2=y
+CONFIG_KEXEC=y
+CONFIG_UTIL_LINUX=y
 CONFIG_LVM2=y
 CONFIG_MBEDTLS=y
-CONFIG_DROPBEAR=y
+CONFIG_PCIUTILS=y
+#Runtime tools to write to EC/MSR
+CONFIG_IOTOOLS=y
 CONFIG_MSRTOOLS=y
+#Remote attestation support
+# TPM2 requirements
+#CONFIG_TPM2_TSS=y
+#CONFIG_OPENSSL=y
+#Remote Attestation common tools
+CONFIG_POPT=y
+CONFIG_QRENCODE=y
+CONFIG_TPMTOTP=y
+#HOTP based remote attestation for supported USB Security dongle
+#With/Without TPM support
 #CONFIG_HOTPKEY=y
-
-#Uncomment only one of the following block
-#Required for graphical gui-init (FBWhiptail)
+#Nitrokey Storage admin tool (deprecated)
+#CONFIG_NKSTORECLI=n
+#GUI Support
+#FBWhiptail based (Graphical):
 #CONFIG_CAIRO=y
 #CONFIG_FBWHIPTAIL=y
-#
 #text-based init (generic-init and gui-init)
 CONFIG_NEWT=y
 CONFIG_SLANG=y
-
+#Additional tools (tools.cpio):
+#SSH server (requires ethernet drivers, eg: CONFIG_LINUX_E1000E)
+CONFIG_DROPBEAR=y
 endif
 
+#Runtime on-demand additional hardware support (modules.cpio)
 export CONFIG_LINUX_USB_COMPANION_CONTROLLER=y
-CONFIG_LINUX_USB=y
-CONFIG_LINUX_E1000=y
 
-#Uncomment only one BOOTSCRIPT:
-#Whiptail-based init (text-based or FBWhiptail)
+
+#Runtime configuration
+#Automatically boot if HOTP is valid
+export CONFIG_AUTO_BOOT_TIMEOUT=5
+#TPM2 requirements
+#export CONFIG_TPM2_TOOLS=y
+#export CONFIG_PRIMARY_KEY_TYPE=ecc
+#TPM1 requirements
+export CONFIG_TPM=y
 export CONFIG_BOOTSCRIPT=/bin/gui-init
-#
 #text-based original init:
 #export CONFIG_BOOTSCRIPT=/bin/generic-init
 export CONFIG_BOOT_REQ_HASH=n
@@ -65,9 +90,6 @@ export CONFIG_BOOT_REQ_ROLLBACK=n
 export CONFIG_BOOT_RECOVERY_SERIAL="/dev/ttyS0"
 export CONFIG_BOOT_KERNEL_ADD="console=ttyS0 console=tty systemd.zram=0"
 export CONFIG_BOOT_KERNEL_REMOVE="quiet rhgb splash"
-
-export CONFIG_TPM=y
-
 export CONFIG_BOOT_DEV="/dev/vda1"
 export CONFIG_BOARD_NAME="qemu-coreboot-whiptail-tpm1"
 

--- a/boards/qemu-coreboot-whiptail-tpm2-hotp/qemu-coreboot-whiptail-tpm2-hotp.config
+++ b/boards/qemu-coreboot-whiptail-tpm2-hotp/qemu-coreboot-whiptail-tpm2-hotp.config
@@ -7,9 +7,15 @@ export CONFIG_COREBOOT=y
 export CONFIG_COREBOOT_VERSION=4.22.01
 export CONFIG_LINUX_VERSION=5.10.5
 
+CONFIG_COREBOOT_CONFIG=config/coreboot-qemu-tpm2.config
+CONFIG_LINUX_CONFIG=config/linux-qemu.config
+
 #Enable only one RESTRICTED/BASIC boot modes below to test them manually (we cannot inject config under QEMU (no internal flashing)
 #export CONFIG_RESTRICTED_BOOT=y
 #export CONFIG_BASIC=y
+
+#Enable HAVE_GPG_KEY_BACKUP to test GPG key backup drive (we cannot inject config under QEMU (no internal flashing))
+#export CONFIG_HAVE_GPG_KEY_BACKUP=y
 
 #Enable DEBUG output
 export CONFIG_DEBUG_OUTPUT=y
@@ -17,48 +23,67 @@ export CONFIG_ENABLE_FUNCTION_TRACING_OUTPUT=y
 #Enable TPM2 pcap output under /tmp
 export CONFIG_TPM2_CAPTURE_PCAP=y
 
-CONFIG_COREBOOT_CONFIG=config/coreboot-qemu-tpm2.config
-CONFIG_LINUX_CONFIG=config/linux-qemu.config
+#On-demand hardware support (modules.cpio)
+CONFIG_LINUX_USB=y
+CONFIG_LINUX_E1000=y
+#CONFIG_MOBILE_TETHERING=y
 
+
+
+#Modules packed into tools.cpio
 ifeq "$(CONFIG_UROOT)" "y"
 CONFIG_BUSYBOX=n
 else
-CONFIG_KEXEC=y
-CONFIG_QRENCODE=y
-CONFIG_TPMTOTP=y
-CONFIG_POPT=y
-CONFIG_FLASHTOOLS=y
-CONFIG_FLASHROM=y
-CONFIG_PCIUTILS=y
-CONFIG_UTIL_LINUX=y
 CONFIG_CRYPTSETUP2=y
+CONFIG_FLASHROM=y
+CONFIG_FLASHTOOLS=y
 CONFIG_GPG2=y
+CONFIG_KEXEC=y
+CONFIG_UTIL_LINUX=y
 CONFIG_LVM2=y
 CONFIG_MBEDTLS=y
-CONFIG_DROPBEAR=y
+CONFIG_PCIUTILS=y
+#Runtime tools to write to EC/MSR
+CONFIG_IOTOOLS=y
 CONFIG_MSRTOOLS=y
+#Remote attestation support
+# TPM2 requirements
+CONFIG_TPM2_TSS=y
+CONFIG_OPENSSL=y
+#Remote Attestation common tools
+CONFIG_POPT=y
+CONFIG_QRENCODE=y
+CONFIG_TPMTOTP=y
+#HOTP based remote attestation for supported USB Security dongle
+#With/Without TPM support
 CONFIG_HOTPKEY=y
-export CONFIG_AUTO_BOOT_TIMEOUT=5
-
-#Uncomment only one of the following block
-#Required for graphical gui-init (FBWhiptail)
+#Nitrokey Storage admin tool (deprecated)
+#CONFIG_NKSTORECLI=n
+#GUI Support
+#FBWhiptail based (Graphical):
 #CONFIG_CAIRO=y
 #CONFIG_FBWHIPTAIL=y
-#
 #text-based init (generic-init and gui-init)
 CONFIG_NEWT=y
 CONFIG_SLANG=y
-
+#Additional tools (tools.cpio):
+#SSH server (requires ethernet drivers, eg: CONFIG_LINUX_E1000E)
+CONFIG_DROPBEAR=y
 endif
 
+#Runtime on-demand additional hardware support (modules.cpio)
 export CONFIG_LINUX_USB_COMPANION_CONTROLLER=y
-CONFIG_LINUX_USB=y
-CONFIG_LINUX_E1000=y
 
-#Uncomment only one BOOTSCRIPT:
-#Whiptail-based init (text-based or FBWhiptail)
+
+#Runtime configuration
+#Automatically boot if HOTP is valid
+export CONFIG_AUTO_BOOT_TIMEOUT=5
+#TPM2 requirements
+export CONFIG_TPM2_TOOLS=y
+export CONFIG_PRIMARY_KEY_TYPE=ecc
+#TPM1 requirements
+#export CONFIG_TPM=y
 export CONFIG_BOOTSCRIPT=/bin/gui-init
-#
 #text-based original init:
 #export CONFIG_BOOTSCRIPT=/bin/generic-init
 export CONFIG_BOOT_REQ_HASH=n
@@ -66,13 +91,6 @@ export CONFIG_BOOT_REQ_ROLLBACK=n
 export CONFIG_BOOT_RECOVERY_SERIAL="/dev/ttyS0"
 export CONFIG_BOOT_KERNEL_ADD="console=ttyS0 console=tty systemd.zram=0"
 export CONFIG_BOOT_KERNEL_REMOVE="quiet rhgb splash"
-
-#TPM2 requirements
-export CONFIG_TPM2_TOOLS=y
-export CONFIG_PRIMARY_KEY_TYPE=ecc
-CONFIG_TPM2_TSS=y
-CONFIG_OPENSSL=y
-
 export CONFIG_BOOT_DEV="/dev/vda1"
 export CONFIG_BOARD_NAME="qemu-coreboot-whiptail-tpm2-hotp"
 

--- a/boards/qemu-coreboot-whiptail-tpm2/qemu-coreboot-whiptail-tpm2.config
+++ b/boards/qemu-coreboot-whiptail-tpm2/qemu-coreboot-whiptail-tpm2.config
@@ -6,6 +6,9 @@ export CONFIG_COREBOOT=y
 export CONFIG_COREBOOT_VERSION=4.22.01
 export CONFIG_LINUX_VERSION=5.10.5
 
+CONFIG_COREBOOT_CONFIG=config/coreboot-qemu-tpm2.config
+CONFIG_LINUX_CONFIG=config/linux-qemu.config
+
 #Enable only one RESTRICTED/BASIC boot modes below to test them manually (we cannot inject config under QEMU (no internal flashing)
 #export CONFIG_RESTRICTED_BOOT=y
 #export CONFIG_BASIC=y
@@ -19,47 +22,67 @@ export CONFIG_ENABLE_FUNCTION_TRACING_OUTPUT=y
 #Enable TPM2 pcap output under /tmp
 export CONFIG_TPM2_CAPTURE_PCAP=y
 
-CONFIG_COREBOOT_CONFIG=config/coreboot-qemu-tpm2.config
-CONFIG_LINUX_CONFIG=config/linux-qemu.config
+#On-demand hardware support (modules.cpio)
+CONFIG_LINUX_USB=y
+CONFIG_LINUX_E1000=y
+#CONFIG_MOBILE_TETHERING=y
 
+
+
+#Modules packed into tools.cpio
 ifeq "$(CONFIG_UROOT)" "y"
 CONFIG_BUSYBOX=n
 else
-CONFIG_KEXEC=y
-CONFIG_QRENCODE=y
-CONFIG_TPMTOTP=y
-CONFIG_POPT=y
-CONFIG_FLASHTOOLS=y
-CONFIG_FLASHROM=y
-CONFIG_PCIUTILS=y
-CONFIG_UTIL_LINUX=y
 CONFIG_CRYPTSETUP2=y
+CONFIG_FLASHROM=y
+CONFIG_FLASHTOOLS=y
 CONFIG_GPG2=y
+CONFIG_KEXEC=y
+CONFIG_UTIL_LINUX=y
 CONFIG_LVM2=y
 CONFIG_MBEDTLS=y
-CONFIG_DROPBEAR=y
+CONFIG_PCIUTILS=y
+#Runtime tools to write to EC/MSR
+CONFIG_IOTOOLS=y
 CONFIG_MSRTOOLS=y
+#Remote attestation support
+# TPM2 requirements
+CONFIG_TPM2_TSS=y
+CONFIG_OPENSSL=y
+#Remote Attestation common tools
+CONFIG_POPT=y
+CONFIG_QRENCODE=y
+CONFIG_TPMTOTP=y
+#HOTP based remote attestation for supported USB Security dongle
+#With/Without TPM support
 #CONFIG_HOTPKEY=y
-
-#Uncomment only one of the following block
-#Required for graphical gui-init (FBWhiptail)
+#Nitrokey Storage admin tool (deprecated)
+#CONFIG_NKSTORECLI=n
+#GUI Support
+#FBWhiptail based (Graphical):
 #CONFIG_CAIRO=y
 #CONFIG_FBWHIPTAIL=y
-#
 #text-based init (generic-init and gui-init)
 CONFIG_NEWT=y
 CONFIG_SLANG=y
-
+#Additional tools (tools.cpio):
+#SSH server (requires ethernet drivers, eg: CONFIG_LINUX_E1000E)
+CONFIG_DROPBEAR=y
 endif
 
+#Runtime on-demand additional hardware support (modules.cpio)
 export CONFIG_LINUX_USB_COMPANION_CONTROLLER=y
-CONFIG_LINUX_USB=y
-CONFIG_LINUX_E1000=y
 
-#Uncomment only one BOOTSCRIPT:
-#Whiptail-based init (text-based or FBWhiptail)
+
+#Runtime configuration
+#Automatically boot if HOTP is valid
+export CONFIG_AUTO_BOOT_TIMEOUT=5
+#TPM2 requirements
+export CONFIG_TPM2_TOOLS=y
+export CONFIG_PRIMARY_KEY_TYPE=ecc
+#TPM1 requirements
+#export CONFIG_TPM=y
 export CONFIG_BOOTSCRIPT=/bin/gui-init
-#
 #text-based original init:
 #export CONFIG_BOOTSCRIPT=/bin/generic-init
 export CONFIG_BOOT_REQ_HASH=n
@@ -67,13 +90,6 @@ export CONFIG_BOOT_REQ_ROLLBACK=n
 export CONFIG_BOOT_RECOVERY_SERIAL="/dev/ttyS0"
 export CONFIG_BOOT_KERNEL_ADD="console=ttyS0 console=tty systemd.zram=0"
 export CONFIG_BOOT_KERNEL_REMOVE="quiet rhgb splash"
-
-#TPM2 requirements
-export CONFIG_TPM2_TOOLS=y
-export CONFIG_PRIMARY_KEY_TYPE=ecc
-CONFIG_TPM2_TSS=y
-CONFIG_OPENSSL=y
-
 export CONFIG_BOOT_DEV="/dev/vda1"
 export CONFIG_BOARD_NAME="qemu-coreboot-whiptail-tpm2"
 

--- a/initrd/bin/kexec-boot
+++ b/initrd/bin/kexec-boot
@@ -151,13 +151,12 @@ if [ "$dryrun" = "y" ]; then exit 0; fi
 
 echo "Loading the new kernel:"
 echo "$kexeccmd"
-DO_WITH_DEBUG eval "$kexeccmd" \
+# DO_WITH_DEBUG captures the debug output from stderr to the log, we don't need
+# it on the console as well
+DO_WITH_DEBUG eval "$kexeccmd" 2>/dev/null \
 || die "Failed to load the new kernel"
 
 if [ "$CONFIG_DEBUG_OUTPUT" = "y" ];then
-	#Repeat kexec command that will be executed since in debug
-	DEBUG "kexeccmd= $kexeccmd"
-
 	#Ask user if they want to continue booting without echoing back the input (-s)
 	read -s -n 1 -p "[DEBUG] Continue booting? [Y/n]: " debug_boot_confirm
 	echo

--- a/initrd/bin/kexec-boot
+++ b/initrd/bin/kexec-boot
@@ -151,7 +151,7 @@ if [ "$dryrun" = "y" ]; then exit 0; fi
 
 echo "Loading the new kernel:"
 echo "$kexeccmd"
-DO_WITH_DEBUG "$kexeccmd" \
+DO_WITH_DEBUG eval "$kexeccmd" \
 || die "Failed to load the new kernel"
 
 if [ "$CONFIG_DEBUG_OUTPUT" = "y" ];then

--- a/initrd/bin/kexec-boot
+++ b/initrd/bin/kexec-boot
@@ -151,7 +151,7 @@ if [ "$dryrun" = "y" ]; then exit 0; fi
 
 echo "Loading the new kernel:"
 echo "$kexeccmd"
-eval "$kexeccmd" \
+DO_WITH_DEBUG "$kexeccmd" \
 || die "Failed to load the new kernel"
 
 if [ "$CONFIG_DEBUG_OUTPUT" = "y" ];then

--- a/initrd/bin/kexec-insert-key
+++ b/initrd/bin/kexec-insert-key
@@ -61,7 +61,8 @@ if [ "$unseal_failed" = "y" ]; then
 		-n 1 \
 		-p "Do you wish to boot and use the LUKS Disk Recovery Key? [Y/n] " \
 		confirm_boot
-
+	echo
+	
 	if [ "$confirm_boot" != 'y' \
 		-a "$confirm_boot" != 'Y' \
 		-a -n "$confirm_boot" ] \

--- a/initrd/bin/oem-factory-reset
+++ b/initrd/bin/oem-factory-reset
@@ -496,7 +496,9 @@ gpg_key_factory_reset() {
     fi
     # If Nitrokey Storage is inserted, reset AES keys as well
     if lsusb | grep -q "20a0:4109" && [ -x /bin/hotp_verification ]; then
+        DEBUG "Nitrokey Storage detected, resetting AES keys..."
         /bin/hotp_verification regenerate ${ADMIN_PIN_DEF}
+        DEBUG "Restarting scdaemon to remove possible exclusive lock of dongle"
         killall -9 scdaemon
     fi
     # Toggle forced sig (good security practice, forcing PIN request for each signature request)

--- a/initrd/bin/seal-hotpkey
+++ b/initrd/bin/seal-hotpkey
@@ -26,6 +26,8 @@ fatal_error()
 {
   echo -e "\nERROR: ${1}; press Enter to continue."
   read
+  # get lsusb output for debugging
+  DEBUG "lsusb output: $(lsusb)"
   die "$1"
 }
 

--- a/initrd/etc/ash_functions
+++ b/initrd/etc/ash_functions
@@ -42,6 +42,12 @@ LOG() {
 	echo "LOG: $*" >>/tmp/debug.log
 }
 
+fw_version() {
+	local FW_VER=$(dmesg | grep 'DMI' | grep -o 'BIOS.*' | cut -f2- -d ' ')
+	# chop off date, since will always be epoch w/timeless builds
+	echo "${FW_VER::-10}"
+}
+
 preserve_rom() {
 	TRACE "Under /etc/ash_functions:preserve_rom"
 	new_rom="$1"
@@ -231,6 +237,8 @@ recovery() {
 	# ensure /tmp/config exists for recovery scripts that depend on it
 	touch /tmp/config
 	. /tmp/config
+
+	DEBUG "Board $CONFIG_BOARD - version $(fw_version)"
 
 	if [ "$CONFIG_TPM" = "y" ]; then
 		DEBUG "Extending TPM PCR 4 for recovery shell access"

--- a/initrd/etc/ash_functions
+++ b/initrd/etc/ash_functions
@@ -37,6 +37,11 @@ TRACE() {
 	fi
 }
 
+# Write directly to the debug log (but not kmsg), never appears on console
+LOG() {
+	echo "LOG: $*" >>/tmp/debug.log
+}
+
 preserve_rom() {
 	TRACE "Under /etc/ash_functions:preserve_rom"
 	new_rom="$1"

--- a/initrd/etc/ash_functions
+++ b/initrd/etc/ash_functions
@@ -23,8 +23,9 @@ warn() {
 }
 
 DEBUG() {
-	if [ "$CONFIG_DEBUG_OUTPUT" = "y" ];then
-		echo "DEBUG: $*" | while read line; do
+	if [ "$CONFIG_DEBUG_OUTPUT" = "y" ]; then
+		# fold -s -w 960 will wrap lines at 960 characters on the last space before the limit
+		echo "DEBUG: $*" | fold -s -w 960 | while read line; do
 			echo "$line" | tee -a /tmp/debug.log /dev/kmsg >/dev/null
 		done
 	fi

--- a/initrd/etc/functions
+++ b/initrd/etc/functions
@@ -94,7 +94,7 @@ DO_WITH_DEBUG() {
 	# - We capture PIPESTATUS[0] whether the command succeeds or fails,
 	#   since we don't know whether the pipeline status will be that of the
 	#   command or 'tee' (depends on set -o pipefail).
-	if ! "$@" 2> >(tee /dev/stderr | SINK_DEBUG "$1 err") | tee >(SINK_DEBUG "$1 out"); then
+	if ! "$@" 2> >(tee /dev/stderr | SINK_DEBUG "$1 stderr") | tee >(SINK_DEBUG "$1 stdout"); then
 		exit_status="${PIPESTATUS[0]}"
 	else
 		exit_status="${PIPESTATUS[0]}"

--- a/initrd/etc/functions
+++ b/initrd/etc/functions
@@ -12,35 +12,106 @@ mask_param() {
 	fi
 }
 
-# Trace a command with DEBUG, then execute it.
+# Pipe input to this to sink it to the debug log, with a name prefix.
+# If the input is empty, no output is produced, so actual output is
+# readily visible in logs.
+#
+# For example:
+# ls /boot/vmlinux* | SINK_DEBUG "/boot kernels"
+SINK_DEBUG() {
+	local name="$1"
+	local line haveblank
+	# If the input doesn't end with a line break, read won't give us the
+	# last (unterminated) line.  Add a line break with echo to ensure we
+	# don't lose any input.  Buffer up to one blank line so we can avoid
+	# emitting a final (or only) blank line.
+	(cat; echo) | while IFS= read -r line; do
+		[[ -n "$haveblank" ]] && DEBUG "$name: " # Emit buffered blank line
+		if [[ -z "$line" ]]; then
+			haveblank=y
+		else
+			haveblank=
+			DEBUG "$name: $line"
+		fi
+	done
+}
+
+# Trace a command with DEBUG, then execute it.  Trace failed exit status, stdout
+# and stderr, etc.
+#
+# DO_WITH_DEBUG is designed so it can be dropped in to most command invocations
+# without side effects - it adds visibility without actually affecting the
+# execution of the script.  Exit statuses, stdout, and stderr are traced, but
+# they are still returned/written to the caller.
+#
 # A password parameter can be masked by passing --mask-position N before the
 # command to execute, the debug trace will just indicate whether the password
 # was empty or nonempty (which is important when use of a password is optional).
 # N=0 is the name of the command to be executed, N=1 is its first parameter,
 # etc.
+#
+# DO_WITH_DEBUG() can be added in most places where a command is executed to
+# add visibility in the debug log.  For example:
+#
+# [DO_WITH_DEBUG] mount "$BLOCK" "$MOUNTPOINT"
+#   ^-- adding DO_WITH_DEBUG will show the block device, mountpoint, and whether
+#   the mount fails
+#
+# [DO_WITH_DEBUG --mask-position 7] tpmr seal "$KEY" "$IDX" "$pcrs" "$pcrf" "$size" "$PASSWORD"
+#   ^-- trace the resulting invocation, but mask the password in the log
+#
+# if ! [DO_WITH_DEBUG] umount "$MOUNTPOINT"; then [...]
+#   ^-- it can be used when the exit status is checked, like the condition of `if`
+#
+# hotp_token_info="$([DO_WITH_DEBUG] hotp_verification info)"
+#   ^-- output of hotp_verification info becomes visible in debug log while
+#   still being captured by script
+#
+# [DO_WITH_DEBUG] umount "$MOUNTPOINT" &>/dev/null || true
+#   ^-- if the command's stdout/stderr/failure are ignored, this still works the
+#   same way with DO_WITH_DEBUG
 DO_WITH_DEBUG() {
-	local exit_status
+	local exit_status=0
 	local cmd_output
-	DEBUG "PATH: $PATH"
-	local cmd=("$@")
 	if [[ "$1" == "--mask-position" ]]; then
 		local mask_position="$2"
 		shift
 		shift
-		cmd=("$@")
-		cmd[$mask_position]="$(mask_param "${cmd[$mask_position]}")"
+		local show_args=("$@")
+		show_args[$mask_position]="$(mask_param "${show_args[$mask_position]}")"
+		DEBUG "${show_args[@]}"
+	else
+		DEBUG "$@"
 	fi
-	if [[ ${#cmd[@]} -eq 1 ]]; then
-		# If there's only one argument, try to split it into multiple arguments
-		read -a cmd <<< "${cmd[0]}"
+
+	# Execute the command and capture the exit status. Tee stdout/stderr to
+	# debug sinks, so they're visible but still can be used by the caller
+	#
+	# This is tricky when set -e / set -o pipefail may or may not be in
+	# effect.
+	# - Putting the command in an `if` ensures set -e won't terminate us,
+	#   and also does not overwrite $? (like `|| true` would).
+	# - We capture PIPESTATUS[0] whether the command succeeds or fails,
+	#   since we don't know whether the pipeline status will be that of the
+	#   command or 'tee' (depends on set -o pipefail).
+	if ! "$@" 2> >(tee /dev/stderr | SINK_DEBUG "$1 err") | tee >(SINK_DEBUG "$1 out"); then
+		exit_status="${PIPESTATUS[0]}"
+	else
+		exit_status="${PIPESTATUS[0]}"
 	fi
-	DEBUG "Executing command with cmd: ${cmd[*]}"
-	# Sanitize the command output by removing special characters
-	cmd_output=$("${cmd[@]}" 2>&1 | sed 's/[&;|`$(){}<>]//g')
-	exit_status=$?
-	DEBUG "Command output: $cmd_output"
-	DEBUG "Command exited with status: $exit_status"
-	return $exit_status
+	if [[ "$exit_status" -ne 0 ]]; then
+		# Trace unsuccessful exit status, but only at DEBUG because this
+		# may be expected.  Include the command name in case the command
+		# also invoked a DO_WITH_DEBUG (it could be a script).
+		DEBUG "$1: exited with status $exit_status"
+	fi
+	# If the command was (probably) not found, trace PATH in case it
+	# prevented the command from being found
+	if [[ "$exit_status" -eq 127 ]]; then
+		DEBUG "$1: PATH=$PATH"
+	fi
+
+	return "$exit_status"
 }
 
 # Trace the current script and function.

--- a/initrd/etc/functions
+++ b/initrd/etc/functions
@@ -17,8 +17,8 @@ mask_param() {
 # readily visible in logs.
 #
 # For example:
-# ls /boot/vmlinux* | SINK_DEBUG "/boot kernels"
-SINK_DEBUG() {
+# ls /boot/vmlinux* | SINK_LOG "/boot kernels"
+SINK_LOG() {
 	local name="$1"
 	local line haveblank
 	# If the input doesn't end with a line break, read won't give us the
@@ -31,7 +31,7 @@ SINK_DEBUG() {
 			haveblank=y
 		else
 			haveblank=
-			DEBUG "$name: $line"
+			LOG "$name: $line"
 		fi
 	done
 }
@@ -94,7 +94,7 @@ DO_WITH_DEBUG() {
 	# - We capture PIPESTATUS[0] whether the command succeeds or fails,
 	#   since we don't know whether the pipeline status will be that of the
 	#   command or 'tee' (depends on set -o pipefail).
-	if ! "$@" 2> >(tee /dev/stderr | SINK_DEBUG "$1 stderr") | tee >(SINK_DEBUG "$1 stdout"); then
+	if ! "$@" 2> >(tee /dev/stderr | SINK_LOG "$1 stderr") | tee >(SINK_LOG "$1 stdout"); then
 		exit_status="${PIPESTATUS[0]}"
 	else
 		exit_status="${PIPESTATUS[0]}"

--- a/initrd/etc/functions
+++ b/initrd/etc/functions
@@ -19,18 +19,28 @@ mask_param() {
 # N=0 is the name of the command to be executed, N=1 is its first parameter,
 # etc.
 DO_WITH_DEBUG() {
-	if [ "$1" == "--mask-position" ]; then
-		mask_position="$2"
+	local exit_status
+	local cmd_output
+	DEBUG "PATH: $PATH"
+	local cmd=("$@")
+	if [[ "$1" == "--mask-position" ]]; then
+		local mask_position="$2"
 		shift
 		shift
-		DEBUG_ARGS=("$@")
-
-		DEBUG_ARGS[$mask_position]="$(mask_param "${DEBUG_ARGS[$mask_position]}")"
-		DEBUG "${DEBUG_ARGS[@]}"
-	else
-		DEBUG "$@"
+		cmd=("$@")
+		cmd[$mask_position]="$(mask_param "${cmd[$mask_position]}")"
 	fi
-	"$@"
+	if [[ ${#cmd[@]} -eq 1 ]]; then
+		# If there's only one argument, try to split it into multiple arguments
+		read -a cmd <<< "${cmd[0]}"
+	fi
+	DEBUG "Executing command with cmd: ${cmd[*]}"
+	# Sanitize the command output by removing special characters
+	cmd_output=$("${cmd[@]}" 2>&1 | sed 's/[&;|`$(){}<>]//g')
+	exit_status=$?
+	DEBUG "Command output: $cmd_output"
+	DEBUG "Command exited with status: $exit_status"
+	return $exit_status
 }
 
 # Trace the current script and function.
@@ -682,7 +692,7 @@ scan_boot_options() {
 
 	if [ -r $option_file ]; then rm $option_file; fi
 	for i in $(find $bootdir -name "$config"); do
-		DO_WITH_DEBUG kexec-parse-boot "$bootdir" "$i" >>$option_file
+		kexec-parse-boot "$bootdir" "$i" >>$option_file
 	done
 	# FC29/30+ may use BLS format grub config files
 	# https://fedoraproject.org/wiki/Changes/BootLoaderSpecByDefault

--- a/initrd/etc/functions
+++ b/initrd/etc/functions
@@ -763,7 +763,7 @@ scan_boot_options() {
 
 	if [ -r $option_file ]; then rm $option_file; fi
 	for i in $(find $bootdir -name "$config"); do
-		kexec-parse-boot "$bootdir" "$i" >>$option_file
+		DO_WITH_DEBUG kexec-parse-boot "$bootdir" "$i" >>$option_file
 	done
 	# FC29/30+ may use BLS format grub config files
 	# https://fedoraproject.org/wiki/Changes/BootLoaderSpecByDefault

--- a/initrd/init
+++ b/initrd/init
@@ -203,9 +203,7 @@ if [ "$CONFIG_BASIC" = "y" ]; then
 fi
 
 # export firmware version
-export FW_VER=$(dmesg | grep 'DMI' | grep -o 'BIOS.*' | cut -f2- -d ' ')
-# chop off date, since will always be epoch w/timeless builds
-FW_VER=${FW_VER::-10}
+export FW_VER=$(fw_version)
 
 # Add our boot devices into the /etc/fstab, if they are defined
 # in the configuration file.


### PR DESCRIPTION
Goal here was to have `kexec -l` output to kmesg so also to console when BOARD is in DEBUG+TRACE mode (configuration settings menu + flash)

@JonathonHall-Purism  please review

A variation of this commit is under #1640 to troubleshoot #1641 more easily and permit users to provide /tmp/debug.log