### PR TITLE
Address inconsistency between docs and OEM factory reset User GPG PIN minimum length requirement

### DIFF
--- a/initrd/bin/oem-factory-reset
+++ b/initrd/bin/oem-factory-reset
@@ -994,7 +994,7 @@ if [ "$use_defaults" == "n" -o "$use_defaults" == "N" ]; then
         echo
         if [ "$prompt_output" != "n" \
             -a "$prompt_output" != "N" ]; then
-            echo -e "\nThey must be each at least 8 characters in length.\n"
+            echo -e "\nThe TPM Owner Password and Admin PIN must be at least 8, the User PIN at least 6 characters in length.\n"
             echo
             if [ "$CONFIG_TPM" = "y" ]; then
                 while [[ ${#TPM_PASS} -lt 8 ]]; do

--- a/initrd/bin/oem-factory-reset
+++ b/initrd/bin/oem-factory-reset
@@ -994,7 +994,7 @@ if [ "$use_defaults" == "n" -o "$use_defaults" == "N" ]; then
         echo
         if [ "$prompt_output" != "n" \
             -a "$prompt_output" != "N" ]; then
-            echo -e "\nThe TPM Owner Password and Admin PIN must be at least 8, the User PIN at least 6 characters in length.\n"
+            echo -e "\nThey must be each at least 8 characters in length.\n"
             echo
             if [ "$CONFIG_TPM" = "y" ]; then
                 while [[ ${#TPM_PASS} -lt 8 ]]; do

--- a/initrd/bin/oem-factory-reset
+++ b/initrd/bin/oem-factory-reset
@@ -1002,8 +1002,8 @@ if [ "$use_defaults" == "n" -o "$use_defaults" == "N" ]; then
                     read TPM_PASS
                 done
             fi
-            while [[ ${#ADMIN_PIN} -lt 6 ]] || [[ ${#ADMIN_PIN} -gt $MAX_HOTP_GPG_PIN_LENGTH ]]; do
-                echo -e -n "\nThis PIN should be between 6 to $MAX_HOTP_GPG_PIN_LENGTH characters in length.\n"
+            while [[ ${#ADMIN_PIN} -lt 8 ]] || [[ ${#ADMIN_PIN} -gt $MAX_HOTP_GPG_PIN_LENGTH ]]; do
+                echo -e -n "\nThis PIN should be between 8 to $MAX_HOTP_GPG_PIN_LENGTH characters in length.\n"
                 echo -e -n "Enter desired GPG Admin PIN: "
                 read ADMIN_PIN
             done
@@ -1011,8 +1011,8 @@ if [ "$use_defaults" == "n" -o "$use_defaults" == "N" ]; then
             # That is, if keys were NOT generated in memory (on smartcard only) or
             #  if keys were generated in memory but are to be moved from local keyring to smartcard
             if [ "$GPG_GEN_KEY_IN_MEMORY" = "n" -o "$GPG_GEN_KEY_IN_MEMORY_COPY_TO_SMARTCARD" = "y" ]; then
-                while [[ ${#USER_PIN} -lt 8 ]] || [[ ${#USER_PIN} -gt $MAX_HOTP_GPG_PIN_LENGTH ]]; do
-                    echo -e -n "\nThis PIN should be between 8 to $MAX_HOTP_GPG_PIN_LENGTH characters in length.\n"
+                while [[ ${#USER_PIN} -lt 6 ]] || [[ ${#USER_PIN} -gt $MAX_HOTP_GPG_PIN_LENGTH ]]; do
+                    echo -e -n "\nThis PIN should be between 6 to $MAX_HOTP_GPG_PIN_LENGTH characters in length.\n"
                     echo -e -n "Enter desired GPG User PIN: "
                     read USER_PIN
                 done

--- a/initrd/bin/oem-factory-reset
+++ b/initrd/bin/oem-factory-reset
@@ -989,11 +989,11 @@ if [ "$use_defaults" == "n" -o "$use_defaults" == "N" ]; then
             luks_new_Disk_Recovery_Key_passphrase=${CUSTOM_SINGLE_PASS}
         fi
     else
-        echo -e -n "Would you like to set distinct PINs/passwords to configure previously stated security components? [y/N]: "
+        echo -e -n "Would you like to set distinct PINs/passwords to configure previously stated security components? [Y/n]: "
         read -n 1 prompt_output
         echo
-        if [ "$prompt_output" == "y" \
-            -o "$prompt_output" == "Y" ]; then
+        if [ "$prompt_output" != "n" \
+            -a "$prompt_output" != "N" ]; then
             echo -e "\nThey must be each at least 8 characters in length.\n"
             echo
             if [ "$CONFIG_TPM" = "y" ]; then
@@ -1011,7 +1011,7 @@ if [ "$use_defaults" == "n" -o "$use_defaults" == "N" ]; then
             # That is, if keys were NOT generated in memory (on smartcard only) or
             #  if keys were generated in memory but are to be moved from local keyring to smartcard
             if [ "$GPG_GEN_KEY_IN_MEMORY" = "n" -o "$GPG_GEN_KEY_IN_MEMORY_COPY_TO_SMARTCARD" = "y" ]; then
-                while [[ ${#USER_PIN} -lt 8 ]] || [[ ${#USER_PIN} -gt $MAX_HOTP_GPG_PIN_LENGTH ]]; do
+                while [[ ${#USER_PIN} -lt 6 ]] || [[ ${#USER_PIN} -gt $MAX_HOTP_GPG_PIN_LENGTH ]]; do
                     echo -e -n "\nThis PIN should be between 8 to $MAX_HOTP_GPG_PIN_LENGTH characters in length.\n"
                     echo -e -n "Enter desired GPG User PIN: "
                     read USER_PIN

--- a/initrd/bin/oem-factory-reset
+++ b/initrd/bin/oem-factory-reset
@@ -994,7 +994,7 @@ if [ "$use_defaults" == "n" -o "$use_defaults" == "N" ]; then
         echo
         if [ "$prompt_output" == "y" \
             -o "$prompt_output" == "Y" ]; then
-            echo -e "\nThey must be each at least 8 characters in length.\n"
+            echo -e "\nThe TPM Owner Password and Admin PIN must be at least 8, the User PIN at least 6 characters in length.\n"
             echo
             if [ "$CONFIG_TPM" = "y" ]; then
                 while [[ ${#TPM_PASS} -lt 8 ]]; do
@@ -1002,8 +1002,8 @@ if [ "$use_defaults" == "n" -o "$use_defaults" == "N" ]; then
                     read TPM_PASS
                 done
             fi
-            while [[ ${#ADMIN_PIN} -lt 8 ]] || [[ ${#ADMIN_PIN} -gt $MAX_HOTP_GPG_PIN_LENGTH ]]; do
-                echo -e -n "\nThis PIN should be between 8 to $MAX_HOTP_GPG_PIN_LENGTH characters in length.\n"
+            while [[ ${#ADMIN_PIN} -lt 6 ]] || [[ ${#ADMIN_PIN} -gt $MAX_HOTP_GPG_PIN_LENGTH ]]; do
+                echo -e -n "\nThis PIN should be between 6 to $MAX_HOTP_GPG_PIN_LENGTH characters in length.\n"
                 echo -e -n "Enter desired GPG Admin PIN: "
                 read ADMIN_PIN
             done

--- a/initrd/bin/oem-factory-reset
+++ b/initrd/bin/oem-factory-reset
@@ -1012,7 +1012,7 @@ if [ "$use_defaults" == "n" -o "$use_defaults" == "N" ]; then
             #  if keys were generated in memory but are to be moved from local keyring to smartcard
             if [ "$GPG_GEN_KEY_IN_MEMORY" = "n" -o "$GPG_GEN_KEY_IN_MEMORY_COPY_TO_SMARTCARD" = "y" ]; then
                 while [[ ${#USER_PIN} -lt 6 ]] || [[ ${#USER_PIN} -gt $MAX_HOTP_GPG_PIN_LENGTH ]]; do
-                    echo -e -n "\nThis PIN should be between 6 to $MAX_HOTP_GPG_PIN_LENGTH characters in length.\n"
+                    echo -e -n "\nThis PIN should be between 8 to $MAX_HOTP_GPG_PIN_LENGTH characters in length.\n"
                     echo -e -n "Enter desired GPG User PIN: "
                     read USER_PIN
                 done

--- a/initrd/bin/oem-factory-reset
+++ b/initrd/bin/oem-factory-reset
@@ -1012,7 +1012,7 @@ if [ "$use_defaults" == "n" -o "$use_defaults" == "N" ]; then
             #  if keys were generated in memory but are to be moved from local keyring to smartcard
             if [ "$GPG_GEN_KEY_IN_MEMORY" = "n" -o "$GPG_GEN_KEY_IN_MEMORY_COPY_TO_SMARTCARD" = "y" ]; then
                 while [[ ${#USER_PIN} -lt 6 ]] || [[ ${#USER_PIN} -gt $MAX_HOTP_GPG_PIN_LENGTH ]]; do
-                    echo -e -n "\nThis PIN should be between 8 to $MAX_HOTP_GPG_PIN_LENGTH characters in length.\n"
+                    echo -e -n "\nThis PIN should be between 6 to $MAX_HOTP_GPG_PIN_LENGTH characters in length.\n"
                     echo -e -n "Enter desired GPG User PIN: "
                     read USER_PIN
                 done

--- a/initrd/bin/oem-factory-reset
+++ b/initrd/bin/oem-factory-reset
@@ -989,11 +989,11 @@ if [ "$use_defaults" == "n" -o "$use_defaults" == "N" ]; then
             luks_new_Disk_Recovery_Key_passphrase=${CUSTOM_SINGLE_PASS}
         fi
     else
-        echo -e -n "Would you like to set distinct PINs/passwords to configure previously stated security components? [Y/n]: "
+        echo -e -n "Would you like to set distinct PINs/passwords to configure previously stated security components? [y/N]: "
         read -n 1 prompt_output
         echo
-        if [ "$prompt_output" != "n" \
-            -a "$prompt_output" != "N" ]; then
+        if [ "$prompt_output" == "y" \
+            -o "$prompt_output" == "Y" ]; then
             echo -e "\nThey must be each at least 8 characters in length.\n"
             echo
             if [ "$CONFIG_TPM" = "y" ]; then
@@ -1011,7 +1011,7 @@ if [ "$use_defaults" == "n" -o "$use_defaults" == "N" ]; then
             # That is, if keys were NOT generated in memory (on smartcard only) or
             #  if keys were generated in memory but are to be moved from local keyring to smartcard
             if [ "$GPG_GEN_KEY_IN_MEMORY" = "n" -o "$GPG_GEN_KEY_IN_MEMORY_COPY_TO_SMARTCARD" = "y" ]; then
-                while [[ ${#USER_PIN} -lt 6 ]] || [[ ${#USER_PIN} -gt $MAX_HOTP_GPG_PIN_LENGTH ]]; do
+                while [[ ${#USER_PIN} -lt 8 ]] || [[ ${#USER_PIN} -gt $MAX_HOTP_GPG_PIN_LENGTH ]]; do
                     echo -e -n "\nThis PIN should be between 8 to $MAX_HOTP_GPG_PIN_LENGTH characters in length.\n"
                     echo -e -n "Enter desired GPG User PIN: "
                     read USER_PIN


### PR DESCRIPTION
Addresses part of #1645:

Lowers the User GPG PIN minimum length to 6 to be consistent with NitroKey app / docs and default PIN length (Admin GPG PIN minimum length is still 8).