### PR TITLE
flake.nix + qemu.mk : add working qemu-canokey usable from all qemu boards by default

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ commands:
 jobs:
   prep_env:
     docker:
-      - image: tlaurion/heads-dev-env:v0.1.4
+      - image: tlaurion/heads-dev-env:v0.1.6
     resource_class: large
     working_directory: ~/heads
     steps:
@@ -111,7 +111,7 @@ jobs:
 
   build_and_persist:
     docker:
-      - image: tlaurion/heads-dev-env:v0.1.4
+      - image: tlaurion/heads-dev-env:v0.1.6
     resource_class: large
     working_directory: ~/heads
     parameters:
@@ -139,7 +139,7 @@ jobs:
 
   build:
     docker:
-      - image: tlaurion/heads-dev-env:v0.1.4
+      - image: tlaurion/heads-dev-env:v0.1.6
     resource_class: large
     working_directory: ~/heads
     parameters:
@@ -160,7 +160,7 @@ jobs:
 
   save_cache:
     docker:
-      - image: tlaurion/heads-dev-env:v0.1.4
+      - image: tlaurion/heads-dev-env:v0.1.6
     resource_class: large
     working_directory: ~/heads
     steps:

--- a/flake.nix
+++ b/flake.nix
@@ -69,23 +69,21 @@
         zlib
         zlib.dev
       ] ++ [
-        # Packages for qemu support with Canokey integration.
+	# Below are overrides to make canokey-qemu library available to qemu built derivative through a qemu override, which qemu is used for other derivatives
+        canokey-qemu # Canokey lib for qemu build-time compilation.
+        (qemu.override {
+          canokeySupport = true; # This override enables Canokey support in QEMU, resulting in -device canokey being available.
+        })
+        # Packages for qemu support with Canokey integration from previous override
         #qemu_full #Heavier but contains qemu-img, kvm and everything else needed to do development cycles under docker
         qemu # To test make BOARD=qemu-coreboot-* boards and then call make BOARD=qemu-coreboot-* with inject_gpg statement, and then run statement.
         qemu_kvm # kvm additional support for qemu without all the qemu-img and everything else under qemu_full
-	#
-	# TODO: make work qemu-canokey not existing in caches:
-	# Below are overrides to make canokey-qemu library availabe to qemu built derivative through override)
-        #canokey doesn't work still even if compiled in, so no reason to add 1Gb of stuff in the image (qemu -device canokey not exposed even if configured in)
-        #canokey-qemu # Canokey lib for qemu build-time compilation.
-        #(qemu.override {
-        #  canokeySupport = true; # This override enables Canokey support in QEMU, resulting in -device canokey being available.
-        #})
       ] ++ [
         # Additional tools for debugging/editing/testing.
         vim # Mostly used amongst us, sorry if you'd like something else, open issue.
         swtpm # QEMU requirement to emulate tpm1/tpm2.
         dosfstools # QEMU requirement to produce valid fs to store exported public key to be fused through inject_key on qemu (so qemu flashrom emulated SPI support).
+        #diffoscope #should we include it? Massive:11 GB uncompressed. Wow?!?!
       ] ++ [
         # Tools for handling binary blobs in their compressed state. (blobs/xx30/vbios_[tw]530.sh)
         bundler

--- a/targets/qemu.mk
+++ b/targets/qemu.mk
@@ -26,6 +26,7 @@ endif
 
 #borrowed from https://github.com/orangecms/webboot/blob/boot-via-qemu/run-webboot.sh
 TPMDIR=$(build)/$(BOARD)/vtpm
+CANOKEY_DIR=$(build)/$(BOARD)
 $(TPMDIR)/.manufacture:
 	mkdir -p "$(TPMDIR)"
 	$(SWTPM_PRESETUP)
@@ -74,6 +75,10 @@ else ifeq "$(USB_TOKEN)" "LibremKey"
 QEMU_USB_TOKEN_DEV := -device usb-host,vendorid=12653,productid=19531
 else ifneq "$(USB_TOKEN)" ""
 QEMU_USB_TOKEN_DEV := -device "usb-host,$(USB_TOKEN)"
+# If no USB token is specified, support canokey by default
+else
+# official instruction -usb -device canokey,file=$HOME/.canokey-file -device canokey
+QEMU_USB_TOKEN_DEV := -usb -device canokey,file=$(CANOKEY_DIR)/.canokey-file
 endif
 
 run: $(TPMDIR)/.manufacture $(ROOT_DISK_IMG) $(MEMORY_SIZE_FILE) $(USB_FD_IMG)


### PR DESCRIPTION
- flake.nix: add canokey-qemu lib, derivate qemu on tope of it and have qemu_kvm depend on qemu derivative
- targets/qemu.mk: modified to had canokey support by default if no "USB_TOKEN=" specified on make run call
- CircleCI: base docker image pull on v0.1.6 containing the newly added derivatives

----

Fixes #1670
Closes https://github.com/linuxboot/heads/issues/1207

---

Finally, bye errors of qemu TCG on top of qemu on top of qubesos with usb error -32.

It's alive!!!
![2024-05-12-132729](https://github.com/linuxboot/heads/assets/827570/800a5ad8-76e9-4dde-9d23-2e2ee03a0db1)



----
Someone.... wants to implement reverse HOTP inside of canokey-qemu???
