### PR TITLE
Hotp version v1.6

### DIFF
--- a/initrd/bin/seal-hotpkey
+++ b/initrd/bin/seal-hotpkey
@@ -138,12 +138,16 @@ if [ "$admin_pin_status" -ne 0 ]; then
     if ! hotp_initialize "$admin_pin" $HOTP_SECRET $counter_value "$HOTPKEY_BRANDING" ; then
       # don't leak key on failure
       shred -n 10 -z -u "$HOTP_SECRET" 2> /dev/null
-      fatal_error "Setting HOTP secret failed"
+      if [ "$HOTPKEY_BRANDING" == "Nitrokey" ]; then
+	fatal_error "Setting HOTP secret failed, to reset nitrokey pin use: nitropy nk3 secrets reset or the Nitrokey App 2"
+      else
+	fatal_error "Setting HOTP secret failed"
+      fi
     fi
   fi
 else 
   # remind user to change admin password
-  echo -e "\nWARNING: default GPG admin PIN detected: please change this as soon as possible."
+  echo -e "\nWARNING: default admin PIN detected: please change this as soon as possible."
 fi
 
 # HOTP key no longer needed

--- a/modules/hotp-verification
+++ b/modules/hotp-verification
@@ -2,12 +2,12 @@ modules-$(CONFIG_HOTPKEY) += hotp-verification
 
 hotp-verification_depends := libusb $(musl_dep)
 
-# v1.5
-hotp-verification_version := 70c04f51387eee8f777e943ba83b6405764a3cd2
+# v1.6
+hotp-verification_version := e9050e0c914e7a8ffef5d1c82a014e0e2bf79346
 hotp-verification_dir := hotp-verification-$(hotp-verification_version)
 hotp-verification_tar := nitrokey-hotp-verification-$(hotp-verification_version).tar.gz
 hotp-verification_url := https://github.com/Nitrokey/nitrokey-hotp-verification/archive/$(hotp-verification_version).tar.gz
-hotp-verification_hash := 5244b6b514117f955a03be2363fd51567a125cb8dc904d1bd89351be27eb8bb3
+hotp-verification_hash := 480c978d3585eee73b9aa5186b471d4caeeeeba411217e1544eef7cfd90312ac
 
 hotp-verification_target := \
 	$(MAKE_JOBS) \


### PR DESCRIPTION
This is needed to get the nitrokey 3 with 1.7.1 firmware to work on heads.

The Error Message is there to make the user aware that resetting the admin pin of the secrets app in the NK 3 Firmware is currently only possible with nitropy and the Nitrokey App 2 and not within heads. 
  
Tested on:
NV41Nitropad : NK3 1.6; NK 1.7.1; NK Storage; NK Pro