### PR TITLE
Use nixos-unstable channel's prebuilt qemu_full with canokey support builtin from nix cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ commands:
 jobs:
   prep_env:
     docker:
-      - image: tlaurion/heads-dev-env:v0.1.8
+      - image: tlaurion/heads-dev-env:v0.1.9
     resource_class: large
     working_directory: ~/heads
     steps:
@@ -111,7 +111,7 @@ jobs:
 
   build_and_persist:
     docker:
-      - image: tlaurion/heads-dev-env:v0.1.8
+      - image: tlaurion/heads-dev-env:v0.1.9
     resource_class: large
     working_directory: ~/heads
     parameters:
@@ -139,7 +139,7 @@ jobs:
 
   build:
     docker:
-      - image: tlaurion/heads-dev-env:v0.1.8
+      - image: tlaurion/heads-dev-env:v0.1.9
     resource_class: large
     working_directory: ~/heads
     parameters:
@@ -160,7 +160,7 @@ jobs:
 
   save_cache:
     docker:
-      - image: tlaurion/heads-dev-env:v0.1.8
+      - image: tlaurion/heads-dev-env:v0.1.9
     resource_class: large
     working_directory: ~/heads
     steps:

--- a/README.md
+++ b/README.md
@@ -94,15 +94,37 @@ docker run -e DISPLAY=$DISPLAY --network host --rm -ti -v $(pwd):$(pwd) -w $(pwd
 
 Maintenance notes on docker image
 ===
-Redo the steps above in case the flake.nix or nix.lock changes. Then publish on docker hub:
+Redo the steps above in case the flake.nix or nix.lock changes. Commit changes. Then publish on docker hub:
 
 ```
-docker tag linuxboot/heads:dev-env tlaurion/heads-dev-env:vx.y.z
-docker push tlaurion/heads-dev-env:vx.y.z
-#test against CircleCI in PR. Merge.
-#make last version the latest
-docker tag tlaurion/heads-dev-env:vx.y.z tlaurion/heads-dev-env:latest
-docker push tlaurion/heads-dev-env:latest
+#put relevant things in variables:
+docker_version="vx.y.z" && docker_hub_repo="tlaurion/heads-dev-env"
+#update pinned packages to latest available ones if needed, modify flake.nix derivatives if needed:
+nix flakes update
+#modify CircleCI image to use newly pushed docker image
+sed "s@\(image: \)\(.*\):\(v[0-9]*\.[0-9]*\.[0-9]*\)@\1\2:$docker_version@" -i .circleci/config.yml
+# commit changes
+git commit --signoff -m "Bump nix develop based docker image to $docker_hub_repo:$docker_version"
+#use commited flake.nix and flake.lock in nix develop
+nix --print-build-logs --verbose develop --ignore-environment --command true
+#build new docker image from nix develop environement
+nix build .#dockerImage && docker load < result
+#tag produced docker image with new version
+docker tag linuxboot/heads:dev-env "$docker_hub_repo:$docker_version"
+#push newly created docker image to docker hub
+docker push "$docker_hub_repo:$docker_version"
+#test with CircleCI in PR. Merge.
+git push ...
+#make last tested docker image version the latest
+docker tag "$docker_hub_repo:$docker_version" "$docker_hub_repo:latest"
+docker push "$docker_hub_repo:latest"
+```
+
+This can be put in reproducible oneliners to ease maintainership.
+
+Test image in dirty mode:
+```
+docker_version="vx.y.z" && docker_hub_repo="tlaurion/heads-dev-env" && sed "s@\(image: \)\(.*\):\(v[0-9]*\.[0-9]*\.[0-9]*\)@\1\2:$docker_version@" -i .circleci/config.yml && nix --print-build-logs --verbose develop --ignore-environment --command true && nix build .#dockerImage && docker load < result && docker tag linuxboot/heads:dev-env "$docker_hub_repo:$docker_version" && docker push "$docker_hub_repo:$docker_version"
 ```
 
 Notes:

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1715534503,
-        "narHash": "sha256-5ZSVkFadZbFP1THataCaSf0JH2cAH3S29hU9rrxTEqk=",
+        "lastModified": 1716509168,
+        "narHash": "sha256-4zSIhSRRIoEBwjbPm3YiGtbd8HDWzFxJjw5DYSDy1n8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2057814051972fa1453ddfb0d98badbea9b83c06",
+        "rev": "bfb7a882678e518398ce9a31a881538679f6f092",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -41,24 +41,24 @@
         flex
         gawk
         git
-        gnat
+        gnat # required for libgfxinit under coreboot, hacked around for kgpe-d16
         gnugrep
         gnumake
         gnused
         gnutar
         gzip
-        imagemagick # For bootsplash manipulation.
-        innoextract # ROM extraction for dGPU.
+        imagemagick # For bootsplash manipulation
+        innoextract # ROM extraction for dGPU
         libtool
         m4
         ncurses5 # make menuconfig and slang
-        openssl #needed for talos-2 kernel build
+        openssl # needed for talos-2 kernel build
         parted
         patch
         perl
         pkg-config
-        python3 # me_cleaner, coreboot.
-        rsync # coreboot.
+        python3 # me_cleaner, coreboot
+        rsync # coreboot
         sharutils
         texinfo
         unzip
@@ -69,23 +69,14 @@
         zlib
         zlib.dev
       ] ++ [
-	# Below are overrides to make canokey-qemu library available to qemu built derivative through a qemu override, which qemu is used for other derivatives
-        #canokey-qemu # Canokey lib for qemu build-time compilation.
-        #(qemu.override {
-        #  canokeySupport = true; # This override enables Canokey support in QEMU, resulting in -device canokey being available.
-        #})
-        # Packages for qemu support with Canokey integration from previous override
-        qemu_full #Heavier but contains qemu-img, kvm and everything else needed to do development/testing cycles under docker
-        #qemu # To test make BOARD=qemu-coreboot-* boards and then call make BOARD=qemu-coreboot-* with inject_gpg statement, and then run statement.
-        #qemu_kvm # kvm additional support for qemu without all the qemu-img and everything else under qemu_full
+        qemu_full #Heavier then qemu + qemu_kvm, but contains qemu-img + kvm and everything else needed to do development/testing cycles under docker
       ] ++ [
-        # Additional tools for debugging/editing/testing.
-        vim # Mostly used amongst us, sorry if you'd like something else, open issue.
-        swtpm # QEMU requirement to emulate tpm1/tpm2.
+        # Additional tools for debugging/editing/testing
+        vim # Mostly used amongst us, sorry if you'd like something else, open issue
+        swtpm # QEMU requirement to emulate tpm1/tpm2
         dosfstools # QEMU requirement to produce valid fs to store exported public key to be fused through inject_key on qemu (so qemu flashrom emulated SPI support).
-        diffoscopeMinimal # Not sure exactly what is packed here, let's try.
-        gnupg #to inject public key inside of qemu create rom through inject_gpg target of targets/qemu.mk TODO: remove when pflash supported by flashrom
-        #diffoscope #should we include it? Massive:11 GB uncompressed. Wow?!?!
+        diffoscopeMinimal # Not sure exactly what is packed here, let's try. Might need diffoscope if something is missing
+        gnupg #to inject public key inside of qemu create rom through inject_gpg target of targets/qemu.mk TODO: remove when pflash supported by flashrom + modify code
         less # so 'git log' is usable
       ] ++ [
         # Tools for handling binary blobs in their compressed state. (blobs/xx30/vbios_[tw]530.sh)

--- a/flake.nix
+++ b/flake.nix
@@ -70,12 +70,12 @@
         zlib.dev
       ] ++ [
 	# Below are overrides to make canokey-qemu library available to qemu built derivative through a qemu override, which qemu is used for other derivatives
-        canokey-qemu # Canokey lib for qemu build-time compilation.
-        (qemu.override {
-          canokeySupport = true; # This override enables Canokey support in QEMU, resulting in -device canokey being available.
-        })
+        #canokey-qemu # Canokey lib for qemu build-time compilation.
+        #(qemu.override {
+        #  canokeySupport = true; # This override enables Canokey support in QEMU, resulting in -device canokey being available.
+        #})
         # Packages for qemu support with Canokey integration from previous override
-        qemu_full #Heavier but contains qemu-img, kvm and everything else needed to do development cycles under docker
+        qemu_full #Heavier but contains qemu-img, kvm and everything else needed to do development/testing cycles under docker
         #qemu # To test make BOARD=qemu-coreboot-* boards and then call make BOARD=qemu-coreboot-* with inject_gpg statement, and then run statement.
         #qemu_kvm # kvm additional support for qemu without all the qemu-img and everything else under qemu_full
       ] ++ [
@@ -86,6 +86,7 @@
         diffoscopeMinimal # Not sure exactly what is packed here, let's try.
         gnupg #to inject public key inside of qemu create rom through inject_gpg target of targets/qemu.mk TODO: remove when pflash supported by flashrom
         #diffoscope #should we include it? Massive:11 GB uncompressed. Wow?!?!
+        less # so 'git log' is usable
       ] ++ [
         # Tools for handling binary blobs in their compressed state. (blobs/xx30/vbios_[tw]530.sh)
         bundler


### PR DESCRIPTION
~WiP: not yet under nixos-unstable. See https://github.com/linuxboot/heads/pull/1687/commits/c7d1495a0a1478c872ad62e3cd9c9d14d96043ff log for details.~ 
EDIT: part of nixos-unstable as of this PR, having called `nix flake update` to update flake.lock to pin to new package list including qemu built with canokey by default as per https://nixpk.gs/pr-tracker.html?pr=311914 PR inclusion and hydra having built all derivatives, downloadable from cache for flake.nix based develop to build docker image reproducibly.

Notes:
- the magical part of this is that the nix develop produced docker image is reproducible. One can recreate the docker image per instructions and then pull my image and see that all layers were already cached! This is pure magic.
- Compressed Docker image size went from 1.43Gb for v0.1.8 to 1.24Gb, as can be observed under https://hub.docker.com/r/tlaurion/heads-dev-env/tags
- updated READEM.md with note to help me maintain this in the future and for others to produce their own docker images based on their flake.nix preferences
- Opened https://github.com/linuxboot/heads/discussions/1690 for RFC so that the docker image stabilizes sooner then later

---

Track:
- [x] https://nixpk.gs/pr-tracker.html?pr=311914
- [x] nix flake update
- [x] rebuild docker and push v0.1.9
- [x] Ready to merge! ~when CircleCI board builds all succeed.~

---

Todo:

- [x] @JonathonHall-Purism ready for review, assigned to you. Merge when ready
- [x]  `docker tag tlaurion/heads-dev-env:v0.1.9 tlaurion/heads-dev-env:latest && docker push tlaurion/heads-dev-env:latest`