### PR TITLE
All Intel CPU based boards: add cpufreq=xen:hwp in an attempt to fix xen related powersave issues that is not enabled by default under QubesOS

### DIFF
--- a/boards/librem_11/librem_11.config
+++ b/boards/librem_11/librem_11.config
@@ -33,7 +33,7 @@ export CONFIG_TPM=n
 export CONFIG_BOOTSCRIPT=/bin/gui-init
 export CONFIG_BOOT_REQ_HASH=n
 export CONFIG_BOOT_REQ_ROLLBACK=n
-export CONFIG_BOOT_KERNEL_ADD=""
+export CONFIG_BOOT_KERNEL_ADD="cpufreq=xen:hwp"
 export CONFIG_BOOT_KERNEL_REMOVE=""
 export CONFIG_BOOT_DEV="/dev/nvme0n1p1"
 export CONFIG_BOARD_NAME="Librem 11"

--- a/boards/librem_13v2/librem_13v2.config
+++ b/boards/librem_13v2/librem_13v2.config
@@ -33,7 +33,7 @@ export CONFIG_TPM=y
 export CONFIG_BOOTSCRIPT=/bin/gui-init
 export CONFIG_BOOT_REQ_HASH=n
 export CONFIG_BOOT_REQ_ROLLBACK=n
-export CONFIG_BOOT_KERNEL_ADD=""
+export CONFIG_BOOT_KERNEL_ADD="cpufreq=xen:hwp"
 export CONFIG_BOOT_KERNEL_REMOVE=""
 export CONFIG_BOOT_DEV="/dev/nvme0n1p1"
 export CONFIG_BOARD_NAME="Librem 13 v2/v3"

--- a/boards/librem_13v4/librem_13v4.config
+++ b/boards/librem_13v4/librem_13v4.config
@@ -33,7 +33,7 @@ export CONFIG_TPM=y
 export CONFIG_BOOTSCRIPT=/bin/gui-init
 export CONFIG_BOOT_REQ_HASH=n
 export CONFIG_BOOT_REQ_ROLLBACK=n
-export CONFIG_BOOT_KERNEL_ADD=""
+export CONFIG_BOOT_KERNEL_ADD="cpufreq=xen:hwp"
 export CONFIG_BOOT_KERNEL_REMOVE=""
 export CONFIG_BOOT_DEV="/dev/nvme0n1p1"
 export CONFIG_BOARD_NAME="Librem 13 v4"

--- a/boards/librem_14/librem_14.config
+++ b/boards/librem_14/librem_14.config
@@ -32,7 +32,7 @@ export CONFIG_SUPPORT_USB_KEYBOARD=y
 export CONFIG_BOOTSCRIPT=/bin/gui-init
 export CONFIG_BOOT_REQ_HASH=n
 export CONFIG_BOOT_REQ_ROLLBACK=n
-export CONFIG_BOOT_KERNEL_ADD=""
+export CONFIG_BOOT_KERNEL_ADD="cpufreq=xen:hwp"
 export CONFIG_BOOT_KERNEL_REMOVE=""
 export CONFIG_BOOT_DEV="/dev/nvme0n1p1"
 export CONFIG_BOARD_NAME="Librem 14"

--- a/boards/librem_15v3/librem_15v3.config
+++ b/boards/librem_15v3/librem_15v3.config
@@ -33,7 +33,7 @@ export CONFIG_TPM=y
 export CONFIG_BOOTSCRIPT=/bin/gui-init
 export CONFIG_BOOT_REQ_HASH=n
 export CONFIG_BOOT_REQ_ROLLBACK=n
-export CONFIG_BOOT_KERNEL_ADD=""
+export CONFIG_BOOT_KERNEL_ADD="cpufreq=xen:hwp"
 export CONFIG_BOOT_KERNEL_REMOVE=""
 export CONFIG_BOOT_DEV="/dev/nvme0n1p1"
 export CONFIG_BOARD_NAME="Librem 15 v3"

--- a/boards/librem_15v4/librem_15v4.config
+++ b/boards/librem_15v4/librem_15v4.config
@@ -34,7 +34,7 @@ export CONFIG_TPM=y
 export CONFIG_BOOTSCRIPT=/bin/gui-init
 export CONFIG_BOOT_REQ_HASH=n
 export CONFIG_BOOT_REQ_ROLLBACK=n
-export CONFIG_BOOT_KERNEL_ADD=""
+export CONFIG_BOOT_KERNEL_ADD="cpufreq=xen:hwp"
 export CONFIG_BOOT_KERNEL_REMOVE=""
 export CONFIG_BOOT_DEV="/dev/nvme0n1p1"
 export CONFIG_BOARD_NAME="Librem 15 v4"

--- a/boards/librem_l1um/librem_l1um.config
+++ b/boards/librem_l1um/librem_l1um.config
@@ -32,7 +32,7 @@ export CONFIG_TPM=y
 export CONFIG_BOOTSCRIPT=/bin/gui-init
 export CONFIG_BOOT_REQ_HASH=n
 export CONFIG_BOOT_REQ_ROLLBACK=n
-export CONFIG_BOOT_KERNEL_ADD="intel_iommu=on"
+export CONFIG_BOOT_KERNEL_ADD="intel_iommu=oncpufreq=xen:hwp"
 export CONFIG_BOOT_KERNEL_REMOVE="plymouth.ignore-serial-consoles"
 export CONFIG_BOOT_DEV="/dev/nvme0n1p1"
 export CONFIG_BOARD_NAME="Librem Server L1UM"

--- a/boards/librem_l1um_v2/librem_l1um_v2.config
+++ b/boards/librem_l1um_v2/librem_l1um_v2.config
@@ -35,7 +35,7 @@ CONFIG_PRIMARY_KEY_TYPE=ecc
 export CONFIG_BOOTSCRIPT=/bin/gui-init
 export CONFIG_BOOT_REQ_HASH=n
 export CONFIG_BOOT_REQ_ROLLBACK=n
-export CONFIG_BOOT_KERNEL_ADD=""
+export CONFIG_BOOT_KERNEL_ADD="cpufreq=xen:hwp"
 export CONFIG_BOOT_KERNEL_REMOVE="plymouth.ignore-serial-consoles"
 export CONFIG_BOOT_RECOVERY_SERIAL="/dev/ttyS0"
 export CONFIG_BOOT_DEV="/dev/nvme0n1p1"

--- a/boards/librem_mini/librem_mini.config
+++ b/boards/librem_mini/librem_mini.config
@@ -33,7 +33,7 @@ export CONFIG_TPM=n
 export CONFIG_BOOTSCRIPT=/bin/gui-init
 export CONFIG_BOOT_REQ_HASH=n
 export CONFIG_BOOT_REQ_ROLLBACK=n
-export CONFIG_BOOT_KERNEL_ADD=""
+export CONFIG_BOOT_KERNEL_ADD="cpufreq=xen:hwp"
 export CONFIG_BOOT_KERNEL_REMOVE=""
 export CONFIG_BOOT_DEV="/dev/nvme0n1p1"
 export CONFIG_BOARD_NAME="Librem Mini"

--- a/boards/librem_mini_v2/librem_mini_v2.config
+++ b/boards/librem_mini_v2/librem_mini_v2.config
@@ -33,7 +33,7 @@ export CONFIG_TPM=n
 export CONFIG_BOOTSCRIPT=/bin/gui-init
 export CONFIG_BOOT_REQ_HASH=n
 export CONFIG_BOOT_REQ_ROLLBACK=n
-export CONFIG_BOOT_KERNEL_ADD=""
+export CONFIG_BOOT_KERNEL_ADD="cpufreq=xen:hwp"
 export CONFIG_BOOT_KERNEL_REMOVE=""
 export CONFIG_BOOT_DEV="/dev/nvme0n1p1"
 export CONFIG_BOARD_NAME="Librem Mini v2"

--- a/boards/nitropad-ns50/nitropad-ns50.config
+++ b/boards/nitropad-ns50/nitropad-ns50.config
@@ -67,7 +67,7 @@ export CONFIG_PRIMARY_KEY_TYPE=ecc
 export CONFIG_BOOTSCRIPT=/bin/gui-init
 export CONFIG_BOOT_REQ_HASH=n
 export CONFIG_BOOT_REQ_ROLLBACK=n
-export CONFIG_BOOT_KERNEL_ADD=""
+export CONFIG_BOOT_KERNEL_ADD="cpufreq=xen:hwp"
 export CONFIG_BOOT_KERNEL_REMOVE="intel_iommu=on intel_iommu=igfx_off"
 export CONFIG_BOOT_DEV="/dev/nvme0n1"
 export CONFIG_BOARD_NAME="Nitropad NS50"

--- a/boards/nitropad-nv41/nitropad-nv41.config
+++ b/boards/nitropad-nv41/nitropad-nv41.config
@@ -67,7 +67,7 @@ export CONFIG_PRIMARY_KEY_TYPE=ecc
 export CONFIG_BOOTSCRIPT=/bin/gui-init
 export CONFIG_BOOT_REQ_HASH=n
 export CONFIG_BOOT_REQ_ROLLBACK=n
-export CONFIG_BOOT_KERNEL_ADD=""
+export CONFIG_BOOT_KERNEL_ADD="cpufreq=xen:hwp"
 export CONFIG_BOOT_KERNEL_REMOVE="intel_iommu=on intel_iommu=igfx_off"
 export CONFIG_BOOT_DEV="/dev/nvme0n1"
 export CONFIG_BOARD_NAME="Nitropad NV41"

--- a/boards/qemu-coreboot-fbwhiptail-tpm1-hotp/qemu-coreboot-fbwhiptail-tpm1-hotp.config
+++ b/boards/qemu-coreboot-fbwhiptail-tpm1-hotp/qemu-coreboot-fbwhiptail-tpm1-hotp.config
@@ -89,7 +89,7 @@ export CONFIG_BOOTSCRIPT=/bin/gui-init
 export CONFIG_BOOT_REQ_HASH=n
 export CONFIG_BOOT_REQ_ROLLBACK=n
 export CONFIG_BOOT_RECOVERY_SERIAL="/dev/ttyS0"
-export CONFIG_BOOT_KERNEL_ADD="console=ttyS0 console=tty systemd.zram=0"
+export CONFIG_BOOT_KERNEL_ADD="console=ttyS0 console=tty systemd.zram=0cpufreq=xen:hwp"
 export CONFIG_BOOT_KERNEL_REMOVE="quiet rhgb splash"
 export CONFIG_BOOT_DEV="/dev/vda1"
 export CONFIG_BOARD_NAME="qemu-coreboot-fbwhiptail-tpm1-hotp"

--- a/boards/qemu-coreboot-fbwhiptail-tpm1/qemu-coreboot-fbwhiptail-tpm1.config
+++ b/boards/qemu-coreboot-fbwhiptail-tpm1/qemu-coreboot-fbwhiptail-tpm1.config
@@ -87,7 +87,7 @@ export CONFIG_BOOTSCRIPT=/bin/gui-init
 export CONFIG_BOOT_REQ_HASH=n
 export CONFIG_BOOT_REQ_ROLLBACK=n
 export CONFIG_BOOT_RECOVERY_SERIAL="/dev/ttyS0"
-export CONFIG_BOOT_KERNEL_ADD="console=ttyS0 console=tty systemd.zram=0"
+export CONFIG_BOOT_KERNEL_ADD="console=ttyS0 console=tty systemd.zram=0cpufreq=xen:hwp"
 export CONFIG_BOOT_KERNEL_REMOVE="quiet rhgb splash"
 export CONFIG_BOOT_DEV="/dev/vda1"
 export CONFIG_BOARD_NAME="qemu-coreboot-fbwhiptail-tpm1"

--- a/boards/qemu-coreboot-fbwhiptail-tpm2-hotp/qemu-coreboot-fbwhiptail-tpm2-hotp.config
+++ b/boards/qemu-coreboot-fbwhiptail-tpm2-hotp/qemu-coreboot-fbwhiptail-tpm2-hotp.config
@@ -88,7 +88,7 @@ export CONFIG_BOOTSCRIPT=/bin/gui-init
 export CONFIG_BOOT_REQ_HASH=n
 export CONFIG_BOOT_REQ_ROLLBACK=n
 export CONFIG_BOOT_RECOVERY_SERIAL="/dev/ttyS0"
-export CONFIG_BOOT_KERNEL_ADD="console=ttyS0 console=tty systemd.zram=0"
+export CONFIG_BOOT_KERNEL_ADD="console=ttyS0 console=tty systemd.zram=0cpufreq=xen:hwp"
 export CONFIG_BOOT_KERNEL_REMOVE="quiet rhgb splash"
 export CONFIG_BOOT_DEV="/dev/vda1"
 export CONFIG_BOARD_NAME="qemu-coreboot-fbwhiptail-tpm2-hotp"

--- a/boards/qemu-coreboot-fbwhiptail-tpm2/qemu-coreboot-fbwhiptail-tpm2.config
+++ b/boards/qemu-coreboot-fbwhiptail-tpm2/qemu-coreboot-fbwhiptail-tpm2.config
@@ -87,7 +87,7 @@ export CONFIG_BOOTSCRIPT=/bin/gui-init
 export CONFIG_BOOT_REQ_HASH=n
 export CONFIG_BOOT_REQ_ROLLBACK=n
 export CONFIG_BOOT_RECOVERY_SERIAL="/dev/ttyS0"
-export CONFIG_BOOT_KERNEL_ADD="console=ttyS0 console=tty systemd.zram=0"
+export CONFIG_BOOT_KERNEL_ADD="console=ttyS0 console=tty systemd.zram=0cpufreq=xen:hwp"
 export CONFIG_BOOT_KERNEL_REMOVE="quiet rhgb splash"
 export CONFIG_BOOT_DEV="/dev/vda1"
 export CONFIG_BOARD_NAME="qemu-coreboot-fbwhiptail-tpm2"

--- a/boards/qemu-coreboot-whiptail-tpm1-hotp/qemu-coreboot-whiptail-tpm1-hotp.config
+++ b/boards/qemu-coreboot-whiptail-tpm1-hotp/qemu-coreboot-whiptail-tpm1-hotp.config
@@ -89,7 +89,7 @@ export CONFIG_BOOTSCRIPT=/bin/gui-init
 export CONFIG_BOOT_REQ_HASH=n
 export CONFIG_BOOT_REQ_ROLLBACK=n
 export CONFIG_BOOT_RECOVERY_SERIAL="/dev/ttyS0"
-export CONFIG_BOOT_KERNEL_ADD="console=ttyS0 console=tty systemd.zram=0"
+export CONFIG_BOOT_KERNEL_ADD="console=ttyS0 console=tty systemd.zram=0cpufreq=xen:hwp"
 export CONFIG_BOOT_KERNEL_REMOVE="quiet rhgb splash"
 export CONFIG_BOOT_DEV="/dev/vda1"
 export CONFIG_BOARD_NAME="qemu-coreboot-whiptail-tpm1-hotp"

--- a/boards/qemu-coreboot-whiptail-tpm1/qemu-coreboot-whiptail-tpm1.config
+++ b/boards/qemu-coreboot-whiptail-tpm1/qemu-coreboot-whiptail-tpm1.config
@@ -87,7 +87,7 @@ export CONFIG_BOOTSCRIPT=/bin/gui-init
 export CONFIG_BOOT_REQ_HASH=n
 export CONFIG_BOOT_REQ_ROLLBACK=n
 export CONFIG_BOOT_RECOVERY_SERIAL="/dev/ttyS0"
-export CONFIG_BOOT_KERNEL_ADD="console=ttyS0 console=tty systemd.zram=0"
+export CONFIG_BOOT_KERNEL_ADD="console=ttyS0 console=tty systemd.zram=0cpufreq=xen:hwp"
 export CONFIG_BOOT_KERNEL_REMOVE="quiet rhgb splash"
 export CONFIG_BOOT_DEV="/dev/vda1"
 export CONFIG_BOARD_NAME="qemu-coreboot-whiptail-tpm1"

--- a/boards/qemu-coreboot-whiptail-tpm2-hotp/qemu-coreboot-whiptail-tpm2-hotp.config
+++ b/boards/qemu-coreboot-whiptail-tpm2-hotp/qemu-coreboot-whiptail-tpm2-hotp.config
@@ -88,7 +88,7 @@ export CONFIG_BOOTSCRIPT=/bin/gui-init
 export CONFIG_BOOT_REQ_HASH=n
 export CONFIG_BOOT_REQ_ROLLBACK=n
 export CONFIG_BOOT_RECOVERY_SERIAL="/dev/ttyS0"
-export CONFIG_BOOT_KERNEL_ADD="console=ttyS0 console=tty systemd.zram=0"
+export CONFIG_BOOT_KERNEL_ADD="console=ttyS0 console=tty systemd.zram=0cpufreq=xen:hwp"
 export CONFIG_BOOT_KERNEL_REMOVE="quiet rhgb splash"
 export CONFIG_BOOT_DEV="/dev/vda1"
 export CONFIG_BOARD_NAME="qemu-coreboot-whiptail-tpm2-hotp"

--- a/boards/qemu-coreboot-whiptail-tpm2/qemu-coreboot-whiptail-tpm2.config
+++ b/boards/qemu-coreboot-whiptail-tpm2/qemu-coreboot-whiptail-tpm2.config
@@ -87,7 +87,7 @@ export CONFIG_BOOTSCRIPT=/bin/gui-init
 export CONFIG_BOOT_REQ_HASH=n
 export CONFIG_BOOT_REQ_ROLLBACK=n
 export CONFIG_BOOT_RECOVERY_SERIAL="/dev/ttyS0"
-export CONFIG_BOOT_KERNEL_ADD="console=ttyS0 console=tty systemd.zram=0"
+export CONFIG_BOOT_KERNEL_ADD="console=ttyS0 console=tty systemd.zram=0cpufreq=xen:hwp"
 export CONFIG_BOOT_KERNEL_REMOVE="quiet rhgb splash"
 export CONFIG_BOOT_DEV="/dev/vda1"
 export CONFIG_BOARD_NAME="qemu-coreboot-whiptail-tpm2"

--- a/boards/t420-hotp-maximized/t420-hotp-maximized.config
+++ b/boards/t420-hotp-maximized/t420-hotp-maximized.config
@@ -63,7 +63,7 @@ CONFIG_DROPBEAR=n
 export CONFIG_BOOTSCRIPT=/bin/gui-init
 export CONFIG_BOOT_REQ_HASH=n
 export CONFIG_BOOT_REQ_ROLLBACK=n
-export CONFIG_BOOT_KERNEL_ADD=""
+export CONFIG_BOOT_KERNEL_ADD="cpufreq=xen:hwp"
 export CONFIG_BOOT_KERNEL_REMOVE="intel_iommu=on intel_iommu=igfx_off"
 export CONFIG_BOOT_DEV="/dev/sda1"
 export CONFIG_BOARD_NAME="ThinkPad T420-hotp-maximized"

--- a/boards/t420-maximized/t420-maximized.config
+++ b/boards/t420-maximized/t420-maximized.config
@@ -61,7 +61,7 @@ CONFIG_DROPBEAR=n
 export CONFIG_BOOTSCRIPT=/bin/gui-init
 export CONFIG_BOOT_REQ_HASH=n
 export CONFIG_BOOT_REQ_ROLLBACK=n
-export CONFIG_BOOT_KERNEL_ADD=""
+export CONFIG_BOOT_KERNEL_ADD="cpufreq=xen:hwp"
 export CONFIG_BOOT_KERNEL_REMOVE="intel_iommu=on intel_iommu=igfx_off"
 export CONFIG_BOOT_DEV="/dev/sda1"
 export CONFIG_BOARD_NAME="ThinkPad T420-maximized"

--- a/boards/t430-hotp-maximized/t430-hotp-maximized.config
+++ b/boards/t430-hotp-maximized/t430-hotp-maximized.config
@@ -61,7 +61,7 @@ CONFIG_DROPBEAR=y
 export CONFIG_BOOTSCRIPT=/bin/gui-init
 export CONFIG_BOOT_REQ_HASH=n
 export CONFIG_BOOT_REQ_ROLLBACK=n
-export CONFIG_BOOT_KERNEL_ADD=""
+export CONFIG_BOOT_KERNEL_ADD="cpufreq=xen:hwp"
 export CONFIG_BOOT_KERNEL_REMOVE="intel_iommu=on intel_iommu=igfx_off"
 export CONFIG_BOOT_DEV="/dev/sda1"
 export CONFIG_BOARD_NAME="Thinkpad T430-hotp-maximized"

--- a/boards/t430-maximized/t430-maximized.config
+++ b/boards/t430-maximized/t430-maximized.config
@@ -61,7 +61,7 @@ CONFIG_DROPBEAR=y
 export CONFIG_BOOTSCRIPT=/bin/gui-init
 export CONFIG_BOOT_REQ_HASH=n
 export CONFIG_BOOT_REQ_ROLLBACK=n
-export CONFIG_BOOT_KERNEL_ADD=""
+export CONFIG_BOOT_KERNEL_ADD="cpufreq=xen:hwp"
 export CONFIG_BOOT_KERNEL_REMOVE="intel_iommu=on intel_iommu=igfx_off"
 export CONFIG_BOOT_DEV="/dev/sda1"
 export CONFIG_BOARD_NAME="Thinkpad T430-maximized"

--- a/boards/w530-hotp-maximized/w530-hotp-maximized.config
+++ b/boards/w530-hotp-maximized/w530-hotp-maximized.config
@@ -63,7 +63,7 @@ CONFIG_DROPBEAR=y
 export CONFIG_BOOTSCRIPT=/bin/gui-init
 export CONFIG_BOOT_REQ_HASH=n
 export CONFIG_BOOT_REQ_ROLLBACK=n
-export CONFIG_BOOT_KERNEL_ADD=""
+export CONFIG_BOOT_KERNEL_ADD="cpufreq=xen:hwp"
 export CONFIG_BOOT_KERNEL_REMOVE="intel_iommu=on intel_iommu=igfx_off"
 export CONFIG_BOOT_DEV="/dev/sda1"
 export CONFIG_BOARD_NAME="Thinkpad W530-hotp-maximized"

--- a/boards/w530-maximized/w530-maximized.config
+++ b/boards/w530-maximized/w530-maximized.config
@@ -62,7 +62,7 @@ CONFIG_DROPBEAR=y
 export CONFIG_BOOTSCRIPT=/bin/gui-init
 export CONFIG_BOOT_REQ_HASH=n
 export CONFIG_BOOT_REQ_ROLLBACK=n
-export CONFIG_BOOT_KERNEL_ADD=""
+export CONFIG_BOOT_KERNEL_ADD="cpufreq=xen:hwp"
 export CONFIG_BOOT_KERNEL_REMOVE="intel_iommu=on intel_iommu=igfx_off"
 export CONFIG_BOOT_DEV="/dev/sda1"
 export CONFIG_BOARD_NAME="Thinkpad W530-maximized"

--- a/boards/x220-hotp-maximized/x220-hotp-maximized.config
+++ b/boards/x220-hotp-maximized/x220-hotp-maximized.config
@@ -63,7 +63,7 @@ CONFIG_DROPBEAR=n
 export CONFIG_BOOTSCRIPT=/bin/gui-init
 export CONFIG_BOOT_REQ_HASH=n
 export CONFIG_BOOT_REQ_ROLLBACK=n
-export CONFIG_BOOT_KERNEL_ADD=""
+export CONFIG_BOOT_KERNEL_ADD="cpufreq=xen:hwp"
 export CONFIG_BOOT_KERNEL_REMOVE="intel_iommu=on intel_iommu=igfx_off"
 export CONFIG_BOOT_DEV="/dev/sda1"
 export CONFIG_BOARD_NAME="ThinkPad X220-hotp-maximized"

--- a/boards/x220-maximized/x220-maximized.config
+++ b/boards/x220-maximized/x220-maximized.config
@@ -62,7 +62,7 @@ CONFIG_DROPBEAR=n
 export CONFIG_BOOTSCRIPT=/bin/gui-init
 export CONFIG_BOOT_REQ_HASH=n
 export CONFIG_BOOT_REQ_ROLLBACK=n
-export CONFIG_BOOT_KERNEL_ADD=""
+export CONFIG_BOOT_KERNEL_ADD="cpufreq=xen:hwp"
 export CONFIG_BOOT_KERNEL_REMOVE="intel_iommu=on intel_iommu=igfx_off"
 export CONFIG_BOOT_DEV="/dev/sda1"
 export CONFIG_BOARD_NAME="ThinkPad X220-maximized"

--- a/boards/x230-hotp-legacy/x230-hotp-legacy.config
+++ b/boards/x230-hotp-legacy/x230-hotp-legacy.config
@@ -59,7 +59,7 @@ CONFIG_LINUX_E1000E=n
 export CONFIG_BOOTSCRIPT=/bin/gui-init
 export CONFIG_BOOT_REQ_HASH=n
 export CONFIG_BOOT_REQ_ROLLBACK=n
-export CONFIG_BOOT_KERNEL_ADD=""
+export CONFIG_BOOT_KERNEL_ADD="cpufreq=xen:hwp"
 export CONFIG_BOOT_KERNEL_REMOVE="intel_iommu=on intel_iommu=igfx_off"
 export CONFIG_BOOT_DEV="/dev/sda1"
 export CONFIG_BOARD_NAME="Thinkpad X230-hotp-legacy"

--- a/boards/x230-hotp-maximized-fhd_edp/x230-hotp-maximized-fhd_edp.config
+++ b/boards/x230-hotp-maximized-fhd_edp/x230-hotp-maximized-fhd_edp.config
@@ -75,7 +75,7 @@ CONFIG_DROPBEAR=y
 export CONFIG_BOOTSCRIPT=/bin/gui-init
 export CONFIG_BOOT_REQ_HASH=n
 export CONFIG_BOOT_REQ_ROLLBACK=n
-export CONFIG_BOOT_KERNEL_ADD=""
+export CONFIG_BOOT_KERNEL_ADD="cpufreq=xen:hwp"
 export CONFIG_BOOT_KERNEL_REMOVE="intel_iommu=on intel_iommu=igfx_off"
 export CONFIG_BOOT_DEV="/dev/sda1"
 export CONFIG_BOARD_NAME="Thinkpad X230-hotp-maximized-eDP"

--- a/boards/x230-hotp-maximized/x230-hotp-maximized.config
+++ b/boards/x230-hotp-maximized/x230-hotp-maximized.config
@@ -78,7 +78,7 @@ export CONFIG_TPM=y
 export CONFIG_BOOTSCRIPT=/bin/gui-init
 export CONFIG_BOOT_REQ_HASH=n
 export CONFIG_BOOT_REQ_ROLLBACK=n
-export CONFIG_BOOT_KERNEL_ADD=""
+export CONFIG_BOOT_KERNEL_ADD="cpufreq=xen:hwp"
 export CONFIG_BOOT_KERNEL_REMOVE="intel_iommu=on intel_iommu=igfx_off"
 export CONFIG_BOOT_DEV="/dev/sda1"
 export CONFIG_BOARD_NAME="Thinkpad X230-hotp-maximized"

--- a/boards/x230-hotp-maximized_usb-kb/x230-hotp-maximized_usb-kb.config
+++ b/boards/x230-hotp-maximized_usb-kb/x230-hotp-maximized_usb-kb.config
@@ -71,7 +71,7 @@ CONFIG_DROPBEAR=y
 export CONFIG_BOOTSCRIPT=/bin/gui-init
 export CONFIG_BOOT_REQ_HASH=n
 export CONFIG_BOOT_REQ_ROLLBACK=n
-export CONFIG_BOOT_KERNEL_ADD=""
+export CONFIG_BOOT_KERNEL_ADD="cpufreq=xen:hwp"
 export CONFIG_BOOT_KERNEL_REMOVE="intel_iommu=on intel_iommu=igfx_off"
 export CONFIG_BOOT_DEV="/dev/sda1"
 export CONFIG_BOARD_NAME="Thinkpad X230-hotp-maximized_usb-kb"

--- a/boards/x230-legacy/x230-legacy.config
+++ b/boards/x230-legacy/x230-legacy.config
@@ -52,7 +52,7 @@ CONFIG_DROPBEAR=n
 export CONFIG_BOOTSCRIPT=/bin/gui-init
 export CONFIG_BOOT_REQ_HASH=n
 export CONFIG_BOOT_REQ_ROLLBACK=n
-export CONFIG_BOOT_KERNEL_ADD=""
+export CONFIG_BOOT_KERNEL_ADD="cpufreq=xen:hwp"
 export CONFIG_BOOT_KERNEL_REMOVE="intel_iommu=on intel_iommu=igfx_off"
 export CONFIG_BOOT_DEV="/dev/sda1"
 export CONFIG_BOARD_NAME="Thinkpad X230-legacy"

--- a/boards/x230-maximized-fhd_edp/x230-maximized-fhd_edp.config
+++ b/boards/x230-maximized-fhd_edp/x230-maximized-fhd_edp.config
@@ -74,7 +74,7 @@ CONFIG_DROPBEAR=y
 export CONFIG_BOOTSCRIPT=/bin/gui-init
 export CONFIG_BOOT_REQ_HASH=n
 export CONFIG_BOOT_REQ_ROLLBACK=n
-export CONFIG_BOOT_KERNEL_ADD=""
+export CONFIG_BOOT_KERNEL_ADD="cpufreq=xen:hwp"
 export CONFIG_BOOT_KERNEL_REMOVE="intel_iommu=on intel_iommu=igfx_off"
 export CONFIG_BOOT_DEV="/dev/sda1"
 export CONFIG_BOARD_NAME="Thinkpad X230-maximized-eDP"

--- a/boards/x230-maximized/x230-maximized.config
+++ b/boards/x230-maximized/x230-maximized.config
@@ -65,7 +65,7 @@ CONFIG_DROPBEAR=y
 export CONFIG_BOOTSCRIPT=/bin/gui-init
 export CONFIG_BOOT_REQ_HASH=n
 export CONFIG_BOOT_REQ_ROLLBACK=n
-export CONFIG_BOOT_KERNEL_ADD=""
+export CONFIG_BOOT_KERNEL_ADD="cpufreq=xen:hwp"
 export CONFIG_BOOT_KERNEL_REMOVE="intel_iommu=on intel_iommu=igfx_off"
 export CONFIG_BOOT_DEV="/dev/sda1"
 export CONFIG_BOARD_NAME="Thinkpad X230-maximized"

--- a/boards/z220-cmt-maximized/z220-cmt-maximized.config
+++ b/boards/z220-cmt-maximized/z220-cmt-maximized.config
@@ -57,7 +57,7 @@ export CONFIG_TPM=y
 export CONFIG_BOOTSCRIPT=/bin/gui-init
 export CONFIG_BOOT_REQ_HASH=n
 export CONFIG_BOOT_REQ_ROLLBACK=n
-export CONFIG_BOOT_KERNEL_ADD=""
+export CONFIG_BOOT_KERNEL_ADD="cpufreq=xen:hwp"
 export CONFIG_BOOT_KERNEL_REMOVE="intel_iommu=on intel_iommu=igfx_off"
 export CONFIG_BOOT_DEV="/dev/sda1"
 export CONFIG_BOARD_NAME="Hewlett-Packard Z220 Convertible Minitower"


### PR DESCRIPTION
WiP