### PR TITLE
Add support for modifying background color when using Newt. Adds ncurses to provide terminfo file.

### DIFF
--- a/initrd/bin/config-gui.sh
+++ b/initrd/bin/config-gui.sh
@@ -15,7 +15,7 @@ param=$1
 read_rom() {
   /bin/flash.sh -r "$1"
   if [ ! -s "$1" ]; then
-    whiptail $BG_COLOR_ERROR --title 'ERROR: BIOS Read Failed!' \
+    whiptail_error --title 'ERROR: BIOS Read Failed!' \
       --msgbox "Unable to read BIOS" 0 80
     exit 1
   fi
@@ -95,7 +95,7 @@ while true; do
     )
 
     unset menu_choice
-    whiptail $BG_COLOR_MAIN_MENU --title "Config Management Menu" \
+    whiptail_type $BG_COLOR_MAIN_MENU --title "Config Management Menu" \
     --menu "This menu lets you change settings for the current BIOS session.\n\nAll changes will revert after a reboot,\n\nunless you also save them to the running BIOS." 0 80 10 \
     "${dynamic_config_options[@]}" \
     2>/tmp/whiptail || recovery "GUI menu failed"
@@ -116,7 +116,7 @@ while true; do
     "b" )
       CURRENT_OPTION="$(load_config_value CONFIG_BOOT_DEV)"
       if ! fdisk -l | grep "Disk /dev/" | cut -f2 -d " " | cut -f1 -d ":" > /tmp/disklist.txt ; then
-        whiptail $BG_COLOR_ERROR --title 'ERROR: No bootable devices found' \
+        whiptail_error --title 'ERROR: No bootable devices found' \
           --msgbox "    $ERROR\n\n" 0 80
         exit 1
       fi
@@ -147,7 +147,7 @@ while true; do
       # mount newly selected /boot device
       if ! mount -o ro $SELECTED_FILE /boot 2>/tmp/error ; then
         ERROR=`cat /tmp/error`
-        whiptail $BG_COLOR_ERROR --title 'ERROR: unable to mount /boot' \
+        whiptail_error --title 'ERROR: unable to mount /boot' \
           --msgbox "    $ERROR\n\n" 0 80
         exit 1
       fi
@@ -175,7 +175,7 @@ while true; do
     ;;
     "r" )
       # prompt for confirmation
-      if (whiptail $BG_COLOR_WARNING --title 'Reset Configuration?' \
+      if (whiptail_warning --title 'Reset Configuration?' \
            --yesno "This will clear all GPG keys, clear boot signatures and checksums,
                   \nreset the /boot device, clear/reset the TPM (if present),
                   \nand reflash your BIOS with the cleaned configuration.
@@ -268,7 +268,7 @@ while true; do
       if [ "$CONFIG_ROOT_CHECK_AT_BOOT" != "y" ]; then
         # Root device and directories must be set to enable this
         if [ -z "$CONFIG_ROOT_DEV" ] || [ -z "$CONFIG_ROOT_DIRLIST" ]; then
-          whiptail $BG_COLOR_ERROR --title 'Root Check Not Configured' \
+          whiptail_error --title 'Root Check Not Configured' \
             --msgbox "Set the root device and directories to hash before enabling this feature." 0 80
         elif (whiptail --title 'Enable Root Hash Check at Boot?' \
              --yesno "This will enable checking root hashes each time you boot.
@@ -305,7 +305,7 @@ while true; do
     ;;
     "P" )
       if [ "$CONFIG_RESTRICTED_BOOT" = "y" ]; then
-          whiptail $BG_COLOR_ERROR --title 'Restricted Boot Active' \
+          whiptail_error --title 'Restricted Boot Active' \
             --msgbox "Disable Restricted Boot to enable Basic Mode." 0 80
       elif [ "$CONFIG_BASIC" != "y" ]; then
         if (whiptail --title "Enable $CONFIG_BRAND_NAME Basic Mode?" \
@@ -365,7 +365,7 @@ while true; do
           # disabled.
           if ! wipe-totp >/dev/null 2>/tmp/error; then
             ERROR=$(tail -n 1 /tmp/error | fold -s)
-            whiptail $BG_COLOR_ERROR --title 'ERROR: erasing TOTP secret' \
+            whiptail_error --title 'ERROR: erasing TOTP secret' \
               --msgbox "Erasing TOTP Secret Failed\n\n${ERROR}" 0 80
             exit 1
           fi

--- a/initrd/bin/flash-gui.sh
+++ b/initrd/bin/flash-gui.sh
@@ -8,7 +8,7 @@ set -e -o pipefail
 TRACE_FUNC
 
 if [ "$CONFIG_RESTRICTED_BOOT" = y ]; then
-  whiptail $BG_COLOR_ERROR --title 'Restricted Boot Active' \
+  whiptail_error --title 'Restricted Boot Active' \
     --msgbox "Disable Restricted Boot to flash new firmware." 0 80
   exit 1
 fi
@@ -42,7 +42,7 @@ single_glob() {
 
 while true; do
   unset menu_choice
-  whiptail $BG_COLOR_MAIN_MENU --title "Firmware Management Menu" \
+  whiptail_type $BG_COLOR_MAIN_MENU --title "Firmware Management Menu" \
     --menu "Select the firmware function to perform\n\nRetaining settings copies existing settings to the new firmware:\n* Keeps your GPG keyring\n* Keeps changes to the default /boot device\n\nErasing settings uses the new firmware as-is:\n* Erases any existing GPG keyring\n* Restores firmware to default factory settings\n* Clears out /boot signatures\n\nIf you are just updating your firmware, you probably want to retain\nyour settings." 0 80 10 \
     'f' ' Flash the firmware with a new ROM, retain settings' \
     'c' ' Flash the firmware with a new ROM, erase settings' \
@@ -56,7 +56,7 @@ while true; do
     exit 0
     ;;
   f | c)
-    if (whiptail $BG_COLOR_WARNING --title 'Flash the BIOS with a new ROM' \
+    if (whiptail_warning --title 'Flash the BIOS with a new ROM' \
       --yesno "You will need to insert a USB drive containing your BIOS image (*.zip or\n*.$UPDATE_PLAIN_EXT).\n\nAfter you select this file, this program will reflash your BIOS.\n\nDo you want to proceed?" 0 80); then
       mount_usb
       if grep -q /media /proc/mounts; then
@@ -115,7 +115,7 @@ while true; do
             exit 1
           fi
 
-          if ! whiptail $BG_COLOR_WARNING --title 'Flash ROM?' \
+          if ! whiptail_warning --title 'Flash ROM?' \
             --yesno "This will replace your current ROM with:\n\n$PKG_FILE_DISPLAY\n\nDo you want to proceed?" 0 80; then
             exit 1
           fi
@@ -136,7 +136,7 @@ while true; do
             fi
             ROM="$PKG_EXTRACT/$(basename "$PKG_FILE")"
             ROM_HASH=$(sha256sum "$ROM" | awk '{print $1}')
-            if ! (whiptail $CONFIG_ERROR_BG_COLOR --title 'Flash ROM without integrity check?' \
+            if ! (whiptail_error --title 'Flash ROM without integrity check?' \
               --yesno "You have provided a *.$UPDATE_PLAIN_EXT file. The integrity of the file can not be\nchecked automatically for this file type.\n\nROM: $PKG_FILE_DISPLAY\nSHA256SUM: $ROM_HASH\n\nIf you do not know how to check the file integrity yourself,\nyou should use a *.zip file instead.\n\nIf the file is damaged, you will not be able to boot anymore.\nDo you want to proceed flashing without file integrity check?" 0 80); then
               exit 1
             fi

--- a/initrd/bin/gpg-gui.sh
+++ b/initrd/bin/gpg-gui.sh
@@ -65,7 +65,7 @@ gpg_flash_rom() {
   if (whiptail --title 'BIOS Flashed Successfully' \
       --yesno "Would you like to update the checksums and sign all of the files in /boot?\n\nYou will need your GPG key to continue and this will modify your disk.\n\nOtherwise the system will reboot immediately." 0 80) then
     if ! update_checksums ; then
-      whiptail $BG_COLOR_ERROR --title 'ERROR' \
+      whiptail_error --title 'ERROR' \
         --msgbox "Failed to update checksums / sign default config" 0 80
     fi
   else
@@ -89,7 +89,7 @@ gpg_post_gen_mgmt() {
       whiptail --title "The GPG Key Copied Successfully" \
         --msgbox "${GPG_GEN_KEY}.asc copied successfully." 0 80
     else
-      whiptail $BG_COLOR_ERROR --title 'ERROR: Copy Failed' \
+      whiptail_error --title 'ERROR: Copy Failed' \
         --msgbox "Unable to copy ${GPG_GEN_KEY}.asc to /media" 0 80
     fi
     umount /media
@@ -98,7 +98,7 @@ gpg_post_gen_mgmt() {
       --yesno "Would you like to add the GPG public key you generated to the BIOS?\n\nThis makes it a trusted key used to sign files in /boot\n\n" 0 80) then
       /bin/flash.sh -r /tmp/gpg-gui.rom
       if [ ! -s /tmp/gpg-gui.rom ]; then
-        whiptail $BG_COLOR_ERROR --title 'ERROR: BIOS Read Failed!' \
+        whiptail_error --title 'ERROR: BIOS Read Failed!' \
           --msgbox "Unable to read BIOS" 0 80
         exit 1
       fi
@@ -124,7 +124,7 @@ gpg_add_key_reflash() {
 
       /bin/flash.sh -r /tmp/gpg-gui.rom
       if [ ! -s /tmp/gpg-gui.rom ]; then
-        whiptail $BG_COLOR_ERROR --title 'ERROR: BIOS Read Failed!' \
+        whiptail_error --title 'ERROR: BIOS Read Failed!' \
           --msgbox "Unable to read BIOS" 0 80
         exit 1
       fi
@@ -141,7 +141,7 @@ gpg_add_key_reflash() {
 
 while true; do
   unset menu_choice
-  whiptail $BG_COLOR_MAIN_MENU --title "GPG Management Menu" \
+  whiptail_type $BG_COLOR_MAIN_MENU --title "GPG Management Menu" \
     --menu 'Select the GPG function to perform' 0 80 10 \
     'r' ' Add GPG key to running BIOS and reflash' \
     'a' ' Add GPG key to standalone BIOS image and flash' \
@@ -181,7 +181,7 @@ while true; do
           fi
           cp "$ROM" /tmp/gpg-gui.rom
 
-          if (whiptail $BG_COLOR_WARNING --title 'Flash ROM?' \
+          if (whiptail_warning --title 'Flash ROM?' \
               --yesno "This will replace your old ROM with $ROM\n\nDo you want to proceed?" 0 80) then
             gpg_flash_rom
           else
@@ -218,7 +218,7 @@ while true; do
           whiptail --title "The GPG Key Copied Successfully" \
             --msgbox "public-key.asc copied successfully." 0 80
         else
-          whiptail $BG_COLOR_ERROR --title 'ERROR: Copy Failed' \
+          whiptail_error --title 'ERROR: Copy Failed' \
             --msgbox "Unable to copy public-key.asc to /media" 0 80
         fi
         umount /media

--- a/initrd/bin/gui-init
+++ b/initrd/bin/gui-init
@@ -3,7 +3,7 @@
 
 BOARD_NAME=${CONFIG_BOARD_NAME:-${CONFIG_BOARD}} 
 MAIN_MENU_TITLE="${BOARD_NAME} | $CONFIG_BRAND_NAME Boot Menu"
-export BG_COLOR_MAIN_MENU=""
+export BG_COLOR_MAIN_MENU="normal"
 
 . /etc/functions
 . /etc/gui_functions
@@ -15,6 +15,8 @@ export BG_COLOR_MAIN_MENU=""
 # reset when we reach the main menu so the user can retry from the main menu and
 # # see errors again.
 skip_to_menu="false"
+
+
 
 mount_boot()
 {
@@ -28,8 +30,8 @@ mount_boot()
     fi
 
     # CONFIG_BOOT_DEV doesn't exist or couldn't be mounted, so give user options
-    BG_COLOR_MAIN_MENU=$BG_COLOR_ERROR
-    whiptail $BG_COLOR_ERROR --title "ERROR: No Bootable OS Found!" \
+    BG_COLOR_MAIN_MENU="error"
+    whiptail_error --title "ERROR: No Bootable OS Found!" \
         --menu "    No bootable OS was found on the default boot device $CONFIG_BOOT_DEV.
     How would you like to proceed?" 0 80 4 \
         'b' ' Select a new boot device' \
@@ -45,7 +47,7 @@ mount_boot()
         if [ $? -eq 0 ]; then
           # update CONFIG_BOOT_DEV
           . /tmp/config
-          BG_COLOR_MAIN_MENU=""
+          BG_COLOR_MAIN_MENU="normal"
         fi
         ;;
       u )
@@ -75,17 +77,17 @@ verify_global_hashes()
   if verify_checksums /boot ; then
     return 0
   elif [[ ! -f "$TMP_HASH_FILE" || ! -f "$TMP_TREE_FILE" ]] ; then
-    if (whiptail $BG_COLOR_ERROR --title 'ERROR: Missing File!' \
+    if (whiptail_error --title 'ERROR: Missing File!' \
         --yesno "One of the files containing integrity information for /boot is missing!\n\nIf you are setting up heads for the first time or upgrading from an\nolder version, select Yes to create the missing files.\n\nOtherwise this could indicate a compromise and you should select No to\nreturn to the main menu.\n\nWould you like to create the missing files now?" 0 80) then
       if update_checksums ; then
-        BG_COLOR_MAIN_MENU=""
+        BG_COLOR_MAIN_MENU="normal"
         return 0;
       else
-        whiptail $BG_COLOR_ERROR --title 'ERROR' \
+        whiptail_error --title 'ERROR' \
           --msgbox "Failed to update checksums / sign default config" 0 80
       fi
     fi
-    BG_COLOR_MAIN_MENU=$BG_COLOR_ERROR
+    BG_COLOR_MAIN_MENU="error"
     return 1
   else
     CHANGED_FILES=$(grep -v 'OK$' /tmp/hash_output | cut -f1 -d ':' | tee -a /tmp/hash_output_mismatches)
@@ -110,7 +112,7 @@ verify_global_hashes()
     else
       if [ $CHANGED_FILES_COUNT -gt 10 ]; then
         # drop to console to show full file list
-        whiptail $ERROR_BG_COLOR --title 'ERROR: Boot Hash Mismatch' \
+        whiptail_error --title 'ERROR: Boot Hash Mismatch' \
           --msgbox "${CHANGED_FILES_COUNT} files failed the verification process!\\n\nThis could indicate a compromise!\n\nHit OK to review the list of files.\n\nType \"q\" to exit the list and return." 0 80
 
         echo "Type \"q\" to exit the list and return." >> /tmp/hash_output_mismatches
@@ -123,16 +125,16 @@ verify_global_hashes()
       fi
     fi
 
-    if (whiptail $BG_COLOR_ERROR --title 'ERROR: Boot Hash Mismatch' --yesno "$TEXT" 0 80) then
+    if (whiptail_error --title 'ERROR: Boot Hash Mismatch' --yesno "$TEXT" 0 80) then
       if update_checksums ; then
-        BG_COLOR_MAIN_MENU=""
+        BG_COLOR_MAIN_MENU="normal"
         return 0;
       else
-        whiptail $BG_COLOR_ERROR --title 'ERROR' \
+        whiptail_error --title 'ERROR' \
           --msgbox "Failed to update checksums / sign default config" 0 80
       fi
     fi
-    BG_COLOR_MAIN_MENU=$BG_COLOR_ERROR
+    BG_COLOR_MAIN_MENU="error"
     return 1
   fi
 }
@@ -140,10 +142,10 @@ verify_global_hashes()
 prompt_update_checksums()
 {
   TRACE_FUNC
-  if (whiptail $BG_COLOR_WARNING --title 'Update Checksums and sign all files in /boot' \
+  if (whiptail_warning --title 'Update Checksums and sign all files in /boot' \
       --yesno "You have chosen to update the checksums and sign all of the files in /boot.\n\nThis means that you trust that these files have not been tampered with.\n\nYou will need your GPG key available, and this change will modify your disk.\n\nDo you want to continue?" 0 80) then
     if ! update_checksums ; then
-      whiptail $BG_COLOR_ERROR --title 'ERROR' \
+      whiptail_error --title 'ERROR' \
         --msgbox "Failed to update checksums / sign default config" 0 80
     fi
   fi
@@ -200,7 +202,7 @@ update_totp()
       TOTP=`unseal-totp`
     done
     if [ $? -ne 0 ]; then
-      BG_COLOR_MAIN_MENU=$BG_COLOR_ERROR
+      BG_COLOR_MAIN_MENU="error"
       if [ "$skip_to_menu" = "true" ]; then
         return 1  # Already asked to skip to menu from a prior error
       fi
@@ -210,7 +212,7 @@ update_totp()
       DEBUG "Show PCRs"
       DEBUG "$(pcrs)"
 
-      whiptail $BG_COLOR_ERROR --title "ERROR: TOTP Generation Failed!" \
+      whiptail_error --title "ERROR: TOTP Generation Failed!" \
         --menu "    ERROR: $CONFIG_BRAND_NAME couldn't generate the TOTP code.\n
   If you have just completed a Factory Reset, or just reflashed
   your BIOS, you should generate a new HOTP/TOTP secret.\n
@@ -227,9 +229,9 @@ update_totp()
       option=$(cat /tmp/whiptail)
       case "$option" in 
         g )
-          if (whiptail $BG_COLOR_WARNING --title 'Generate new TOTP/HOTP secret' \
+          if (whiptail_warning --title 'Generate new TOTP/HOTP secret' \
               --yesno "This will erase your old secret and replace it with a new one!\n\nDo you want to proceed?" 0 80) then
-            generate_totp_hotp && update_totp && BG_COLOR_MAIN_MENU="" && reseal_tpm_disk_decryption_key
+            generate_totp_hotp && update_totp && BG_COLOR_MAIN_MENU="normal" && reseal_tpm_disk_decryption_key
           fi
           ;;
         i )
@@ -237,7 +239,7 @@ update_totp()
           return 1
           ;;
         p )
-          reset_tpm && update_totp && BG_COLOR_MAIN_MENU="" && reseal_tpm_disk_decryption_key
+          reset_tpm && update_totp && BG_COLOR_MAIN_MENU="normal" && reseal_tpm_disk_decryption_key
           ;;
         x )
           recovery "User requested recovery shell"
@@ -256,12 +258,12 @@ update_hotp()
       if [ "$skip_to_menu" = "true" ]; then
         return 1  # Already asked to skip to menu from a prior error
       fi
-      if ! whiptail $BG_COLOR_WARNING \
+      if ! whiptail_warning \
           --title "WARNING: Please Insert Your $HOTPKEY_BRANDING" \
           --yes-button "Retry" --no-button "Skip" \
           --yesno "Your $HOTPKEY_BRANDING was not detected.\n\nPlease insert your $HOTPKEY_BRANDING" 0 80 ; then
         HOTP="Error checking code, Insert $HOTPKEY_BRANDING and retry"
-        BG_COLOR_MAIN_MENU=$BG_COLOR_WARNING
+        BG_COLOR_MAIN_MENU="warning"
         return
       fi
     fi
@@ -271,15 +273,15 @@ update_hotp()
     case "$?" in
       0 )
         HOTP="Success"
-        BG_COLOR_MAIN_MENU=""
+        BG_COLOR_MAIN_MENU="normal"
       ;;
       4|7 )	# 4: code was incorrect, 7: code was not a valid HOTP code at all
         HOTP="Invalid code"
-        BG_COLOR_MAIN_MENU=$BG_COLOR_ERROR
+        BG_COLOR_MAIN_MENU="error"
       ;;
       * )
         HOTP="Error checking code, Insert $HOTPKEY_BRANDING and retry"
-        BG_COLOR_MAIN_MENU=$BG_COLOR_WARNING
+        BG_COLOR_MAIN_MENU="warning"
       ;;
     esac
   else
@@ -287,7 +289,7 @@ update_hotp()
   fi
 
   if [[ "$CONFIG_TPM" = n && "$HOTP" = "Invalid code" ]]; then
-    whiptail $BG_COLOR_ERROR --title "ERROR: HOTP Validation Failed!" \
+    whiptail_error --title "ERROR: HOTP Validation Failed!" \
       --menu "ERROR: $CONFIG_BRAND_NAME couldn't validate the HOTP code.\n\nIf you just reflashed your BIOS, you should generate a new TOTP/HOTP secret.\n\nIf you have not just reflashed your BIOS, THIS COULD INDICATE TAMPERING!\n\nHow would you like to proceed?" 0 80 4 \
       'g' ' Generate new TOTP/HOTP secret' \
       'i' ' Ignore error and continue to main menu' \
@@ -297,9 +299,9 @@ update_hotp()
     option=$(cat /tmp/whiptail)
     case "$option" in 
       g )
-        if (whiptail $BG_COLOR_WARNING --title 'Generate new TOTP/HOTP secret' \
+        if (whiptail_warning --title 'Generate new TOTP/HOTP secret' \
             --yesno "This will erase your old secret and replace it with a new one!\n\nDo you want to proceed?" 0 80) then
-          generate_totp_hotp && BG_COLOR_MAIN_MENU="" && reseal_tpm_disk_decryption_key
+          generate_totp_hotp && BG_COLOR_MAIN_MENU="normal" && reseal_tpm_disk_decryption_key
         fi
         ;;
       i )
@@ -338,7 +340,7 @@ clean_boot_check()
   # OS is installed, no kexec files present, no GPG keys in keyring, security token present
   # prompt user to run OEM factory reset
   oem-factory-reset \
-    "Clean Boot Detected - Perform OEM Factory Reset / Re-Ownership?" "$BG_COLOR_WARNING"
+    "Clean Boot Detected - Perform OEM Factory Reset / Re-Ownership?"
 }
 
 check_gpg_key()
@@ -346,11 +348,11 @@ check_gpg_key()
   TRACE_FUNC
   GPG_KEY_COUNT=`gpg -k 2>/dev/null | wc -l`
   if [ $GPG_KEY_COUNT -eq 0 ]; then
-    BG_COLOR_MAIN_MENU=$BG_COLOR_ERROR
+    BG_COLOR_MAIN_MENU="error"
     if [ "$skip_to_menu" = "true" ]; then
       return 1  # Already asked to skip to menu from a prior error
     fi
-    whiptail $BG_COLOR_ERROR --title "ERROR: GPG keyring empty!" \
+    whiptail_error --title "ERROR: GPG keyring empty!" \
       --menu "ERROR: $CONFIG_BRAND_NAME couldn't find any GPG keys in your keyring.\n\nIf this is the first time the system has booted,\nyou should add a public GPG key to the BIOS now.\n\nIf you just reflashed a new BIOS, you'll need to add at least one\npublic key to the keyring.\n\nIf you have not just reflashed your BIOS, THIS COULD INDICATE TAMPERING!\n\nHow would you like to proceed?" 0 80 4 \
       'g' ' Add a GPG key to the running BIOS' \
       'F' ' OEM Factory Reset / Re-Ownership' \
@@ -361,7 +363,7 @@ check_gpg_key()
     option=$(cat /tmp/whiptail)
     case "$option" in 
       g )
-        gpg-gui.sh && BG_COLOR_MAIN_MENU=""
+        gpg-gui.sh && BG_COLOR_MAIN_MENU="normnal"
         ;;
       i )
         skip_to_menu="true"
@@ -392,7 +394,7 @@ show_main_menu()
 {
   TRACE_FUNC
   date=`date "+%Y-%m-%d %H:%M:%S %Z"`
-  whiptail $BG_COLOR_MAIN_MENU --title "$MAIN_MENU_TITLE" \
+  whiptail_type $BG_COLOR_MAIN_MENU --title "$MAIN_MENU_TITLE" \
     --menu "$date\nTOTP: $TOTP | HOTP: $HOTP" 0 80 10 \
     'd' ' Default boot' \
     'r' ' Refresh TOTP/HOTP' \
@@ -424,7 +426,7 @@ show_main_menu()
 show_options_menu()
 {
   TRACE_FUNC
-  whiptail $BG_COLOR_MAIN_MENU --title "$CONFIG_BRAND_NAME Options" \
+  whiptail_type $BG_COLOR_MAIN_MENU --title "$CONFIG_BRAND_NAME Options" \
     --menu "" 0 80 10 \
     'b' ' Boot Options -->' \
     't' ' TPM/TOTP/HOTP Options -->' \
@@ -485,7 +487,7 @@ show_options_menu()
 show_boot_options_menu()
 {
   TRACE_FUNC
-  whiptail $BG_COLOR_MAIN_MENU --title "Boot Options" \
+  whiptail_type $BG_COLOR_MAIN_MENU --title "Boot Options" \
     --menu "Select A Boot Option" 0 80 10 \
     'm' ' Show OS boot menu' \
     'u' ' USB boot' \
@@ -513,7 +515,7 @@ show_boot_options_menu()
 show_tpm_totp_hotp_options_menu()
 {
   TRACE_FUNC
-  whiptail $BG_COLOR_MAIN_MENU --title "TPM/TOTP/HOTP Options" \
+  whiptail_type $BG_COLOR_MAIN_MENU --title "TPM/TOTP/HOTP Options" \
     --menu "Select An Option" 0 80 10 \
     'g' ' Generate new TOTP/HOTP secret' \
     'r' ' Reset the TPM' \
@@ -540,7 +542,7 @@ show_tpm_totp_hotp_options_menu()
 prompt_totp_mismatch()
 {
   TRACE_FUNC
-  if (whiptail $BG_COLOR_WARNING --title "TOTP/HOTP code mismatched" \
+  if (whiptail_warning --title "TOTP/HOTP code mismatched" \
     --yesno "TOTP/HOTP code mismatches could indicate either TPM tampering or clock drift:\n\nTo correct clock drift: 'date -s yyyy-MM-DD hh:mm:ss' in UTC timezone\nand save it to the RTC: 'hwclock -w'\nthen reboot and try again.\n\nWould you like to exit to a recovery console?" 0 80) then
     echo ""
     echo "To correct clock drift: 'date -s yyyy-MM-DD hh:mm:ss' in UTC timezone"
@@ -558,7 +560,7 @@ reset_tpm()
 {
   TRACE_FUNC
   if [ "$CONFIG_TPM" = "y" ]; then
-    if (whiptail $BG_COLOR_WARNING --title 'Reset the TPM' \
+    if (whiptail_warning --title 'Reset the TPM' \
         --yesno "This will clear the TPM and TPM password, replace them with new ones!\n\nDo you want to proceed?" 0 80) then
 
       if ! prompt_new_owner_password; then
@@ -594,7 +596,7 @@ reset_tpm()
       echo "Returning to the main menu"
     fi
   else
-    whiptail $BG_COLOR_ERROR --title 'ERROR: No TPM Detected' --msgbox "This device does not have a TPM.\n\nPress OK to return to the Main Menu" 0 80
+    whiptail_error --title 'ERROR: No TPM Detected' --msgbox "This device does not have a TPM.\n\nPress OK to return to the Main Menu" 0 80
   fi
 }
 
@@ -619,7 +621,7 @@ attempt_default_boot()
   if [ -r "$DEFAULT_FILE" ]; then
     kexec-select-boot -b /boot -c "grub.cfg" -g \
     || recovery "Failed default boot"
-  elif (whiptail $BG_COLOR_WARNING --title 'No Default Boot Option Configured' \
+  elif (whiptail_warning --title 'No Default Boot Option Configured' \
         --yesno "There is no default boot option configured yet.\nWould you like to load a menu of boot options?\nOtherwise you will return to the main menu." 0 80) then
     kexec-select-boot -m -b /boot -c "grub.cfg" -g
   fi
@@ -629,11 +631,11 @@ force_unsafe_boot()
 {
   TRACE_FUNC
   if [ "$CONFIG_RESTRICTED_BOOT" = y ]; then
-      whiptail $BG_COLOR_ERROR --title 'ERROR: Restricted Boot Enabled' --msgbox "Restricted Boot is Enabled, forced boot not allowed.\n\nPress OK to return to the Main Menu" 0 80
+      whiptail_error --title 'ERROR: Restricted Boot Enabled' --msgbox "Restricted Boot is Enabled, forced boot not allowed.\n\nPress OK to return to the Main Menu" 0 80
       return
   fi
   # Run the menu selection in "force" mode, bypassing hash checks
-  if (whiptail $BG_COLOR_WARNING --title 'Unsafe Forced Boot Selected!' \
+  if (whiptail_warning --title 'Unsafe Forced Boot Selected!' \
       --yesno "WARNING: You have chosen to skip all tamper checks and boot anyway.\n\nThis is an unsafe option!\n\nDo you want to proceed?" 0 80) then
     mount_boot && kexec-select-boot -m -b /boot -c "grub.cfg" -g -f
   fi

--- a/initrd/bin/gui-init-basic
+++ b/initrd/bin/gui-init-basic
@@ -3,7 +3,7 @@
 
 BOARD_NAME=${CONFIG_BOARD_NAME:-${CONFIG_BOARD}} 
 MAIN_MENU_TITLE="${BOARD_NAME} | $CONFIG_BRAND_NAME Basic Boot Menu"
-export BG_COLOR_MAIN_MENU=""
+export BG_COLOR_MAIN_MENU="normal"
 
 . /etc/functions
 . /etc/gui_functions
@@ -27,8 +27,8 @@ mount_boot()
     fi
 
     # CONFIG_BOOT_DEV doesn't exist or couldn't be mounted, so give user options
-    BG_COLOR_MAIN_MENU=$BG_COLOR_ERROR
-    whiptail $BG_COLOR_ERROR --title "ERROR: No Bootable OS Found!" \
+    BG_COLOR_MAIN_MENU="error"
+    whiptail_error --title "ERROR: No Bootable OS Found!" \
         --menu "    No bootable OS was found on the default boot device $CONFIG_BOOT_DEV.
     How would you like to proceed?" 0 80 4 \
         'b' ' Select a new boot device' \
@@ -44,7 +44,7 @@ mount_boot()
         if [ $? -eq 0 ]; then
           # update CONFIG_BOOT_DEV
           . /tmp/config
-          BG_COLOR_MAIN_MENU=""
+          BG_COLOR_MAIN_MENU="normal"
         fi
         ;;
       u )
@@ -75,7 +75,7 @@ show_main_menu()
 {
   TRACE_FUNC
   date=`date "+%Y-%m-%d %H:%M:%S %Z"`
-  whiptail $BG_COLOR_MAIN_MENU --title "$MAIN_MENU_TITLE" \
+  whiptail_type $BG_COLOR_MAIN_MENU --title "$MAIN_MENU_TITLE" \
     --menu "$date" 0 80 10 \
     'd' ' Default boot' \
     'o' ' Options -->' \
@@ -103,7 +103,7 @@ show_main_menu()
 show_options_menu()
 {
   TRACE_FUNC
-  whiptail $BG_COLOR_MAIN_MENU --title "$CONFIG_BRAND_NAME Basic Options" \
+  whiptail_type $BG_COLOR_MAIN_MENU --title "$CONFIG_BRAND_NAME Basic Options" \
     --menu "" 0 80 10 \
     'b' ' Boot Options -->' \
     'c' ' Change configuration settings -->' \
@@ -134,7 +134,7 @@ show_options_menu()
 show_boot_options_menu()
 {
   TRACE_FUNC
-  whiptail $BG_COLOR_MAIN_MENU --title "Boot Options" \
+  whiptail_type $BG_COLOR_MAIN_MENU --title "Boot Options" \
     --menu "Select A Boot Option" 0 80 10 \
     'm' ' Show OS boot menu' \
     'u' ' USB boot' \
@@ -176,7 +176,7 @@ attempt_default_boot()
   elif [ -r "$DEFAULT_FILE" ]; then
     kexec-select-boot -b /boot -c "grub.cfg" -g -i -s \
     || recovery "Failed default boot"
-  elif (whiptail $BG_COLOR_WARNING --title 'No Default Boot Option Configured' \
+  elif (whiptail_warning --title 'No Default Boot Option Configured' \
         --yesno "There is no default boot option configured yet.\nWould you like to load a menu of boot options?\nOtherwise you will return to the main menu." 0 80) then
     kexec-select-boot -m -b /boot -c "grub.cfg" -g -i
   fi

--- a/initrd/bin/kexec-select-boot
+++ b/initrd/bin/kexec-select-boot
@@ -3,6 +3,7 @@
 set -e -o pipefail
 . /tmp/config
 . /etc/functions
+. /etc/gui_functions
 
 TRACE_FUNC
 
@@ -87,7 +88,7 @@ verify_global_hashes() {
 	else
 		if [ "$gui_menu" = "y" ]; then
 			CHANGED_FILES=$(grep -v 'OK$' /tmp/hash_output | cut -f1 -d ':')
-			whiptail $BG_COLOR_ERROR --title 'ERROR: Boot Hash Mismatch' \
+			whiptail_error --title 'ERROR: Boot Hash Mismatch' \
 				--msgbox "The following files failed the verification process:\n${CHANGED_FILES}\nExiting to a recovery shell" 0 80
 		fi
 		die "$TMP_HASH_FILE: boot hash mismatch"
@@ -103,7 +104,7 @@ verify_global_hashes() {
 		else
 			# root-hashes-gui.sh handles the GUI error menu, just die here
 			if [ "$gui_menu" = "y" ]; then
-				whiptail $BG_COLOR_ERROR --title 'ERROR: Root Hash Mismatch' \
+				whiptail_error --title 'ERROR: Root Hash Mismatch' \
 					--msgbox "The root hash check failed!\nExiting to a recovery shell" 0 80
 			fi
 			die "root hash mismatch, see /tmp/hash_output_mismatches for details"
@@ -178,7 +179,7 @@ confirm_menu_option() {
 	if [ "$gui_menu" = "y" ]; then
 		default_text="Make default"
 		[[ "$CONFIG_TPM_NO_LUKS_DISK_UNLOCK" = "y" ]] && default_text="${default_text} and boot"
-		whiptail $BG_COLOR_WARNING --title "Confirm boot details" \
+		whiptail_warning --title "Confirm boot details" \
 			--menu "Confirm the boot details for $name:\n\n$(echo $kernel | fold -s -w 80) \n\n" 0 80 8 \
 			-- 'd' "${default_text}" 'y' "Boot one time" \
 			2>/tmp/whiptail || die "Aborting boot attempt"
@@ -256,7 +257,7 @@ default_select() {
 	option=$(head -n $default_index $TMP_MENU_FILE | tail -1)
 	if [ "$option" != "$expectedoption" ]; then
 		if [ "$gui_menu" = "y" ]; then
-			whiptail $BG_COLOR_ERROR --title 'ERROR: Boot Entry Has Changed' \
+			whiptail_error --title 'ERROR: Boot Entry Has Changed' \
 				--msgbox "The list of boot entries has changed\n\nPlease set a new default" 0 80
 		fi
 		warn "Boot entry has changed - please set a new default"
@@ -274,7 +275,7 @@ default_select() {
 		else
 			if [ "$gui_menu" = "y" ]; then
 				CHANGED_FILES=$(grep -v 'OK$' /tmp/hash_output | cut -f1 -d ':')
-				whiptail $BG_COLOR_ERROR --title 'ERROR: Default Boot Hash Mismatch' \
+				whiptail_error --title 'ERROR: Default Boot Hash Mismatch' \
 					--msgbox "The following files failed the verification process:\n${CHANGED_FILES}\nExiting to a recovery shell" 0 80
 			fi
 		fi

--- a/initrd/bin/media-scan
+++ b/initrd/bin/media-scan
@@ -47,7 +47,7 @@ get_menu_option() {
 
 		MENU_OPTIONS="$MENU_OPTIONS a Abort"
 
-		whiptail $BG_COLOR_MAIN_MENU --title "Select your ISO boot option" \
+		whiptail_type $BG_COLOR_MAIN_MENU --title "Select your ISO boot option" \
 			--menu "Choose the ISO boot option [1-$n]:" 0 80 8 \
 			-- $MENU_OPTIONS \
 			2>/tmp/whiptail || die "Aborting boot attempt"

--- a/initrd/bin/mount-usb
+++ b/initrd/bin/mount-usb
@@ -1,6 +1,7 @@
 #!/bin/bash
 # Mount a USB device
 . /etc/functions
+. /etc/gui_functions
 . /etc/luks-functions
 
 TRACE_FUNC
@@ -82,7 +83,7 @@ fi
 list_usb_storage > /tmp/usb_block_devices
 if [ -z "$(cat /tmp/usb_block_devices)" ]; then
   if [ -x /bin/whiptail ]; then
-    whiptail $BG_COLOR --title 'USB Drive Missing' \
+    whiptail_warning --title 'USB Drive Missing' \
       --msgbox "Insert your USB drive and press Enter to continue." 0 80
   else
     echo "+++ USB Drive Missing! Insert your USB drive and press Enter to continue."
@@ -92,7 +93,7 @@ if [ -z "$(cat /tmp/usb_block_devices)" ]; then
   list_usb_storage > /tmp/usb_block_devices
   if [ -z "$(cat /tmp/usb_block_devices)" ]; then
     if [ -x /bin/whiptail ]; then
-      whiptail $BG_COLOR_ERROR --title 'ERROR: USB Drive Missing' \
+      whiptail_error --title 'ERROR: USB Drive Missing' \
         --msgbox "USB Drive Missing! Aborting mount attempt.\n\nPress Enter to continue." 0 80
     else
       echo "!!! ERROR: USB Drive Missing! Aborting mount. Press Enter to continue."
@@ -135,7 +136,7 @@ else
       done < /tmp/usb_disk_list
 
       MENU_OPTIONS="$MENU_OPTIONS a Abort"
-      whiptail $BG_COLOR --title "Select your USB disk" \
+      whiptail --title "Select your USB disk" \
         --menu "Choose your USB disk [1-$n, a to abort]:" 0 80 8 \
         -- $MENU_OPTIONS \
         2>/tmp/whiptail

--- a/initrd/bin/oem-factory-reset
+++ b/initrd/bin/oem-factory-reset
@@ -5,6 +5,7 @@ set -o pipefail
 
 ## External files sourced
 . /etc/functions
+. /etc/gui_functions
 . /etc/luks-functions
 . /tmp/config
 
@@ -66,7 +67,7 @@ whiptail_error() {
     if [ "$msg" = "" ]; then
         die "whiptail error: An error msg is required"
     fi
-    whiptail $BG_COLOR_ERROR --msgbox "${msg}\n\n" $HEIGHT $WIDTH $BG_COLOR_ERROR --title "Error"
+    whiptail_error --msgbox "${msg}\n\n" $HEIGHT $WIDTH --title "Error"
 }
 
 whiptail_error_die() {
@@ -297,7 +298,7 @@ keytocard_subkeys_to_smartcard() {
 prompt_insert_to_be_wiped_thumb_drive() {
     TRACE_FUNC
     #Whiptail warning about having only desired to be wiped thumb drive inserted
-    whiptail $BG_COLOR_WARNING --title 'WARNING: Please insert the thumb drive to be wiped' \
+    whiptail_warning --title 'WARNING: Please insert the thumb drive to be wiped' \
         --msgbox "The thumb drive will be WIPED next.\n\nPlease connect only the thumb drive to be wiped and disconnect others." 0 80 ||
         die "Error displaying warning about having only desired to be wiped thumb drive inserted"
 }
@@ -773,7 +774,7 @@ report_integrity_measurements() {
             enable_usb
             for attempt in 1 2 3; do
                 if ! hotp_verification info >/dev/null 2>&1; then
-                    whiptail $CONFIG_WARNING_BG_COLOR --title "WARNING: Please insert your HOTP enabled USB Security Dongle (Attempt $attempt/3)" --msgbox "Your HOTP enabled USB Security Dongle was not detected.\n\nPlease remove it and insert it again." 0 80
+                    whiptail_warning --title "WARNING: Please insert your HOTP enabled USB Security Dongle (Attempt $attempt/3)" --msgbox "Your HOTP enabled USB Security Dongle was not detected.\n\nPlease remove it and insert it again." 0 80
                 else
                     break
                 fi
@@ -792,11 +793,11 @@ report_integrity_measurements() {
                 ;;
             4)
                 HOTP="Invalid code"
-                MAIN_MENU_BG_COLOR=$CONFIG_ERROR_BG_COLOR
+                BG_COLOR_MAIN_MENU="error"
                 ;;
             *)
                 HOTP="Error checking code, Insert USB Security Dongle and retry"
-                MAIN_MENU_BG_COLOR=$CONFIG_WARNING_BG_COLOR
+                BG_COLOR_MAIN_MENU="warning"
                 ;;
             esac
         else
@@ -813,7 +814,7 @@ report_integrity_measurements() {
         fi
 
         #Show results
-        whiptail $MAIN_MENU_BG_COLOR --title "Measured Integrity Report" --msgbox "$date\nTOTP: $TOTP | HOTP: $HOTP\n/BOOT INTEGRITY: $HASH\n\nPress OK to continue or Ctrl+Alt+Delete to reboot" 0 80
+        whiptail_type $BG_COLOR_MAIN_MENU --title "Measured Integrity Report" --msgbox "$date\nTOTP: $TOTP | HOTP: $HOTP\n/BOOT INTEGRITY: $HASH\n\nPress OK to continue or Ctrl+Alt+Delete to reboot" 0 80
     fi
 
     TRACE_FUNC
@@ -855,7 +856,7 @@ if [ "$CONFIG_TPM" = "y" ]; then
 else
     TPM_STR=""
 fi
-if ! whiptail --yesno "
+if ! whiptail_warning --yesno "
         This operation will automatically:\n
 $TPM_STR
           * ERASE any keys or passwords on the GPG smart card,\n
@@ -865,7 +866,7 @@ $TPM_STR
           * Sign all of the files in /boot with the new GPG key\n\n
         It requires that you already have an OS installed on a\n
         dedicated /boot partition. Do you wish to continue?" \
-    $HEIGHT $WIDTH $CONTINUE $CANCEL $CLEAR $bg_color --title "$title_text"; then
+    $HEIGHT $WIDTH $CONTINUE $CANCEL $CLEAR --title "$title_text"; then
     exit 1
 fi
 

--- a/initrd/bin/oem-system-info-xx30
+++ b/initrd/bin/oem-system-info-xx30
@@ -3,9 +3,10 @@
 
 BOARD_NAME=${CONFIG_BOARD_NAME:-${CONFIG_BOARD}} 
 MAIN_MENU_TITLE="${BOARD_NAME} | Extended System Information"
-export BG_COLOR_MAIN_MENU=""
+export BG_COLOR_MAIN_MENU="normal"
 
 . /etc/functions
+. /etc/gui_functions
 . /etc/luks-functions
 . /tmp/config
 
@@ -54,5 +55,5 @@ TRACE_FUNC
   
   FB_OPTIONS=""
   if whiptail --version |grep "fbwhiptail"; then FB_OPTIONS="--text-size 12"; fi
-  whiptail $BG_COLOR_MAIN_MENU $FB_OPTIONS --title 'System Info' \
+  whiptail_type $BG_COLOR_MAIN_MENU $FB_OPTIONS --title 'System Info' \
 	    --msgbox "${BOARD_NAME}\nFW_VER: ${FW_VER}\nKernel: ${kernel}\nCPU: ${cpustr}  RAM: ${memtotal} GB $battery_status\n$(fdisk -l | grep -e '/dev/sd.:' -e '/dev/nvme.*:' | sed 's/B,.*/B/')\n\n$(cat /tmp/devices_usb_pci)" 0 80

--- a/initrd/bin/root-hashes-gui.sh
+++ b/initrd/bin/root-hashes-gui.sh
@@ -14,7 +14,7 @@ export CONFIG_ROOT_DIRLIST_PRETTY=$(echo $CONFIG_ROOT_DIRLIST | sed -e 's/^/\//;
 
 update_root_checksums() {
   if ! detect_root_device; then
-    whiptail $BG_COLOR_ERROR --title 'ERROR: No Valid Root Disk Found' \
+    whiptail_error --title 'ERROR: No Valid Root Disk Found' \
       --msgbox "No Valid Root Disk Found" 0 80
     die "No Valid Root Disk Found"
   fi
@@ -23,7 +23,7 @@ update_root_checksums() {
   if ! grep -q /boot /proc/mounts ; then
     if ! mount -o rw /boot; then
        unmount_root_device
-       whiptail $BG_COLOR_ERROR --title 'ERROR: Unable to mount /boot' \
+       whiptail_error --title 'ERROR: Unable to mount /boot' \
          --msgbox "Unable to mount /boot" 0 80
        die "Unable to mount /boot"
     fi
@@ -48,7 +48,7 @@ update_root_checksums() {
 }
 check_root_checksums() {
   if ! detect_root_device; then
-    whiptail $BG_COLOR_ERROR --title 'ERROR: No Valid Root Disk Found' \
+    whiptail_error --title 'ERROR: No Valid Root Disk Found' \
       --msgbox "No Valid Root Disk Found" 0 80
     die "No Valid Root Disk Found"
   fi
@@ -57,7 +57,7 @@ check_root_checksums() {
   if ! grep -q /boot /proc/mounts ; then
     if ! mount -o ro /boot; then
        unmount_root_device
-       whiptail $BG_COLOR_ERROR --title 'ERROR: Unable to mount /boot' \
+       whiptail_error --title 'ERROR: Unable to mount /boot' \
          --msgbox "Unable to mount /boot" 0 80
        die "Unable to mount /boot"
     fi
@@ -65,7 +65,7 @@ check_root_checksums() {
 
   # check that root hash file exists
   if [ ! -f ${HASH_FILE} ]; then
-     if (whiptail $BG_COLOR_WARNING --title 'WARNING: No Root Hash File Found' \
+     if (whiptail_warning --title 'WARNING: No Root Hash File Found' \
         --yesno "\nIf you just enabled root hash checking feature,
                 \nthen you need to create the initial hash file.
                 \nOtherwise, This could be caused by tampering.
@@ -81,7 +81,7 @@ check_root_checksums() {
   echo "+++ Checking root hash file signature "
   if ! sha256sum `find /boot/kexec*.txt` | gpgv /boot/kexec.sig - > /tmp/hash_output; then
     ERROR=`cat /tmp/hash_output`
-    whiptail $BG_COLOR_ERROR --title 'ERROR: Signature Failure' \
+    whiptail_error --title 'ERROR: Signature Failure' \
       --msgbox "The signature check on hash files failed:\n${CHANGED_FILES}\nExiting to a recovery shell" 0 80
     unmount_root_device
     die 'Invalid signature'
@@ -94,7 +94,7 @@ check_root_checksums() {
     grep -E -v '^[+-]{3}|[@]{2} ' /tmp/new_file_diff > /tmp/new_file_diff2 # strip any output that's not a file
     mv /tmp/new_file_diff2 /tmp/new_file_diff
     CHANGED_FILES_COUNT=$(wc -l /tmp/new_file_diff | cut -f1 -d ' ')
-    whiptail $BG_COLOR_ERROR --title 'ERROR: Files Added/Removed in Root ' \
+    whiptail_error --title 'ERROR: Files Added/Removed in Root ' \
       --msgbox "${CHANGED_FILES_COUNT} files were added/removed in root!\n\nHit OK to review the list of files.\n\nType \"q\" to exit the list and return to the menu." 0 80
 
     echo "Type \"q\" to exit the list and return to the menu." >> /tmp/new_file_diff
@@ -131,7 +131,7 @@ check_root_checksums() {
   else
     CHANGED_FILES=$(grep -v 'OK$' /tmp/hash_output | cut -f1 -d ':' | tee -a /tmp/hash_output_mismatches)
     CHANGED_FILES_COUNT=$(wc -l /tmp/hash_output_mismatches | cut -f1 -d ' ')
-    whiptail $BG_COLOR_ERROR --title 'ERROR: Root Hash Mismatch' \
+    whiptail_error --title 'ERROR: Root Hash Mismatch' \
       --msgbox "${CHANGED_FILES_COUNT} files failed the verification process!\n\nHit OK to review the list of files.\n\nType \"q\" to exit the list and return to the menu." 0 80
     unmount_root_device
 
@@ -431,7 +431,7 @@ while true; do
   if ! grep -q /boot /proc/mounts ; then
     if ! mount -o ro /boot; then
        unmount_root_device
-       whiptail $BG_COLOR_ERROR --title 'ERROR: Unable to mount /boot' \
+       whiptail_error --title 'ERROR: Unable to mount /boot' \
          --msgbox "Unable to mount /boot" 0 80
        die "Unable to mount /boot"
     fi

--- a/initrd/bin/seal-hotpkey
+++ b/initrd/bin/seal-hotpkey
@@ -2,6 +2,7 @@
 # Retrieve the sealed TOTP secret and initialize a USB Security Dongle with it
 
 . /etc/functions
+. /etc/gui_functions
 
 HOTP_SECRET="/tmp/secret/hotp.key"
 HOTP_COUNTER="/boot/kexec_hotp_counter"
@@ -13,7 +14,7 @@ mount_boot()
   # Mount local disk if it is not already mounted
   if ! grep -q /boot /proc/mounts; then
     if ! mount -o ro /boot; then
-      whiptail $BG_COLOR_ERROR --title 'ERROR' \
+      whiptail_error --title 'ERROR' \
         --msgbox "Couldn't mount /boot.\n\nCheck the /boot device in configuration settings, or perform an OEM reset." 0 80
       return 1
     fi

--- a/initrd/etc/gui_functions
+++ b/initrd/etc/gui_functions
@@ -23,15 +23,51 @@ mount_usb()
   # Mount the USB boot device
   mount-usb && USB_FAILED=0 || ( [ $? -eq 5 ] && exit 1 || USB_FAILED=1 )
   if [ $USB_FAILED -ne 0 ]; then
-    whiptail $BG_COLOR_ERROR --title 'USB Drive Missing' \
+    whiptail_error --title 'USB Drive Missing' \
       --msgbox "Insert your USB drive and press Enter to continue." 0 80
     mount-usb && USB_FAILED=0 || ( [ $? -eq 5 ] && exit 1 || USB_FAILED=1 )
     if [ $USB_FAILED -ne 0 ]; then
-      whiptail $BG_COLOR_ERROR --title 'ERROR: Mounting /media Failed' \
+      whiptail_error --title 'ERROR: Mounting /media Failed' \
         --msgbox "Unable to mount USB device" 0 80
       exit 1
     fi
   fi
+}
+
+# -- Display related functions --
+# Produce a whiptail prompt with 'warning' background, works for fbwhiptail and newt
+whiptail_warning() {
+    if [ -x /bin/fbwhiptail ]; then
+        whiptail $BG_COLOR_WARNING "$@"
+    else
+        env NEWT_COLORS="root=,$TEXT_BG_COLOR_WARNING" whiptail "$@"
+    fi
+}
+
+# Produce a whiptail prompt with 'error' background, works for fbwhiptail and newt
+whiptail_error() {
+    if [ -x /bin/fbwhiptail ]; then
+        whiptail $BG_COLOR_ERROR "$@"
+    else
+        env NEWT_COLORS="root=,$TEXT_BG_COLOR_ERROR" whiptail "$@"
+    fi
+}
+
+# Produce a whiptail prompt of the given type - 'error', 'warning', or 'normal'
+whiptail_type() {
+    local TYPE="$1"
+    shift
+    case "$TYPE" in
+        error)
+            whiptail_error "$@"
+	    ;;
+        warning)
+            whiptail_warning "$@"
+	    ;;
+        normal)
+	    whiptail "$@"
+	    ;;
+    esac
 }
 
 # Create display text for a size in bytes in either MB or GB, unit selected
@@ -107,7 +143,7 @@ file_selector()
 	done < "$FILE_LIST"
 
 	if [ "${#CHOICE_ARGS[@]}" -eq 0 ]; then
-		whiptail $BG_COLOR_ERROR --title 'ERROR: No Files Found' \
+		whiptail_error --title 'ERROR: No Files Found' \
 			--msgbox "No Files found matching the pattern. Aborting." 0 80
 		exit 1
 	fi
@@ -144,7 +180,7 @@ show_system_info()
   cpustr=$(cat /proc/cpuinfo | grep 'model name' | uniq | sed -r 's/\(R\)//;s/\(TM\)//;s/CPU //;s/model name.*: //')
   kernel=$(uname -s -r)
 
-  whiptail $BG_COLOR_MAIN_MENU --title 'System Info' \
+  whiptail_type $BG_COLOR_MAIN_MENU --title 'System Info' \
     --msgbox "${BOARD_NAME}\n\nFW_VER: ${FW_VER}\nKernel: ${kernel}\n\nCPU: ${cpustr}\nRAM: ${memtotal} GB\n$battery_status\n$(fdisk -l | grep -e '/dev/sd.:' -e '/dev/nvme.*:' | sed 's/B,.*/B/')" 0 80
 }
 

--- a/initrd/etc/luks-functions
+++ b/initrd/etc/luks-functions
@@ -129,7 +129,7 @@ interactive_prepare_thumb_drive()
 	if [ -z "$DEVICE" ]; then
 		#warn user to disconnect all external drives
 		if [ -x /bin/whiptail ]; then
-			whiptail $BG_COLOR_WARNING --title "WARNING: Disconnect all external drives" --msgbox \
+			whiptail_warning --title "WARNING: Disconnect all external drives" --msgbox \
 				"WARNING: Please disconnect all external drives before proceeding.\n\nHit Enter to continue." 0 80 \
 				|| die "User cancelled wiping and repartitioning of $DEVICE"
 		else
@@ -206,7 +206,7 @@ confirm_thumb_drive_format()
 
 	MSG="WARNING: Wiping and repartitioning $DEVICE ($DISK_SIZE_DISPLAY) with $LUKS_SIZE_MB MB\n assigned to private LUKS ext4 partition,\n rest assigned to exFAT public partition.\n\nAre you sure you want to continue?"
 	if [ -x /bin/whiptail ]; then
-		whiptail $BG_COLOR_WARNING --title "WARNING: Wiping and repartitioning $DEVICE ($DISK_SIZE_DISPLAY)" --yesno \
+		whiptail_warning --title "WARNING: Wiping and repartitioning $DEVICE ($DISK_SIZE_DISPLAY)" --yesno \
 			"$MSG" 0 80
 	else
 		echo -e -n "$MSG"

--- a/initrd/init
+++ b/initrd/init
@@ -106,8 +106,8 @@ if [ -x /bin/fbwhiptail ]; then
 	export BG_COLOR_WARNING="${CONFIG_WARNING_BG_COLOR:-"--background-gradient 0 0 0 150 125 0"}"
 	export BG_COLOR_ERROR="${CONFIG_ERROR_BG_COLOR:-"--background-gradient 0 0 0 150 0 0"}"
 else
-	export BG_COLOR_WARNING="${CONFIG_WARNING_BG_COLOR:-""}"
-	export BG_COLOR_ERROR="${CONFIG_ERROR_BG_COLOR:-""}"
+	export TEXT_BG_COLOR_WARNING="${CONFIG_WARNING_TEXT_BG_COLOR:-"yellow"}"
+	export TEXT_BG_COLOR_ERROR="${CONFIG_ERROR_TEXT_BG_COLOR:-"red"}"
 fi
 
 if [ "$CONFIG_TPM" = "y" ]; then

--- a/modules/ncurses
+++ b/modules/ncurses
@@ -1,0 +1,29 @@
+modules-y += ncurses
+
+ncurses_depends := $(musl_dep)
+
+ncurses_version := 6.5
+ncurses_dir := ncurses-$(ncurses_version)
+ncurses_tar := ncurses-$(ncurses_version).tar.gz
+ncurses_url := https://invisible-island.net/archives/ncurses/ncurses-$(ncurses_version).tar.gz
+ncurses_hash := 136d91bc269a9a5785e5f9e980bc76ab57428f604ce3e5a5a90cebc767971cc6
+
+ncurses_configure := \
+	CFLAGS="-Os" ./configure \
+	$(CROSS_TOOLS) \
+	--host $(MUSL_ARCH)-elf-linux \
+	--without-ada \
+	--without-cxx \
+	--without-cxx-binding \
+	--without-manpages \
+	--without-shared
+
+#build hack: we cp installed terminfo dir back into build dir to pack terminfo in initrd
+ncurses_target := $(MAKE_JOBS) \
+	$(CROSS_TOOLS) \
+	DESTDIR="$(INSTALL)" \
+	install.data && \
+	cp -vpr $(INSTALL)/usr/share/terminfo "$(build)/$(ncurses_dir)"
+
+ncurses_data := \
+	terminfo/l/linux


### PR DESCRIPTION
- Tested on text mode MSI dGPU board.
- Tested on Chromebook GOP framebuffer mode.

I think I got all of the occurrences in which colors are modified. Open to modification of variable names etc.