### PR TITLE
Makefile: When cloning a repo from Git, update submodules correctly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -392,7 +392,7 @@ define define_module =
     $(build)/$($1_base_dir)/.canary: FORCE
 	if [ ! -e "$$@" ]; then \
 		git clone $($1_repo) "$(build)/$($1_base_dir)"; \
-		git -C "$(build)/$($1_base_dir)" reset --hard $($1_commit_hash) && git submodule update --init --checkout; \
+		git -C "$(build)/$($1_base_dir)" reset --hard $($1_commit_hash) && git -C "$(build)/$($1_base_dir)" submodule update --init --checkout; \
 		echo -n '$($1_repo)|$($1_commit_hash)' > "$$@"; \
 	elif [ "$$$$(cat "$$@")" != '$($1_repo)|$($1_commit_hash)' ]; then \
 		echo "Switching $1 to $($1_repo) at $($1_commit_hash)" && \

--- a/Makefile
+++ b/Makefile
@@ -378,7 +378,9 @@ define define_module =
     # First time:
     #   Checkout the tree instead and create the canary file with repo and
     #   revision so that we know that the files are all present and their
-    #   version.
+    #   version.  Submodules are _not_ checked out, because coreboot has
+    #   many submodules that won't be used, let coreboot check out its own
+    #   submodules during build
     #
     # Other times:
     #   If .canary contains the same repo and revision combination, do nothing.
@@ -392,7 +394,7 @@ define define_module =
     $(build)/$($1_base_dir)/.canary: FORCE
 	if [ ! -e "$$@" ]; then \
 		git clone $($1_repo) "$(build)/$($1_base_dir)"; \
-		git -C "$(build)/$($1_base_dir)" reset --hard $($1_commit_hash) && git -C "$(build)/$($1_base_dir)" submodule update --init --checkout; \
+		git -C "$(build)/$($1_base_dir)" reset --hard $($1_commit_hash); \
 		echo -n '$($1_repo)|$($1_commit_hash)' > "$$@"; \
 	elif [ "$$$$(cat "$$@")" != '$($1_repo)|$($1_commit_hash)' ]; then \
 		echo "Switching $1 to $($1_repo) at $($1_commit_hash)" && \


### PR DESCRIPTION
When cloning a repo from Git, actually change to the repo directory to check out the submodules as well.  Without the -C <dir>, the submodule checkout happened in the Heads repo itself, which has no submodules.

This is important for coreboot being built in CI.  Without this, the coreboot submodules will be checked out automatically by the coreboot build system during the build, meaning they will not be in the prepped module cache.

A trade-off though is that at this point, we don't know what submodules are actually needed - we will clone some that are not needed.  coreboot knows to skip some submodules during the build if they are not needed.

Fixes #1731 