### PR TITLE
targets/qemu.mk: Fix skip-if-exist in swtpm_setup

### DIFF
--- a/targets/qemu.mk
+++ b/targets/qemu.mk
@@ -16,7 +16,7 @@ endif
 
 ifeq "$(CONFIG_TPM2_TSS)" "y"
 SWTPM_TPMVER := --tpm2
-SWTPM_PRESETUP := swtpm_setup --create-config-files root skip-if-exist
+SWTPM_PRESETUP := swtpm_setup --create-config-files root,skip-if-exist
 else
 # TPM1 is the default
 SWTPM_TPMVER :=


### PR DESCRIPTION
Commit 46cad549 ("WiP flake.nix: make docker image usable for...") added 'root' to the swtpm_setup call, but broke skip-if-exist because the flags are supposed to be comma-separated.  swtpm_setup was ignoring skip-if-exist and would fail if the config files exist.

Put a comma there so it works again.