### PR TITLE
flash.sh: Add warning to remind user to not interfere with flashrom operations that will follow

### DIFF
--- a/initrd/bin/flash.sh
+++ b/initrd/bin/flash.sh
@@ -48,6 +48,7 @@ flash_rom() {
       dd if=/tmp/pchstrp9.bin bs=1 count=4 seek=292 of=/tmp/${CONFIG_BOARD}.rom conv=notrunc >/dev/null 2>&1
     fi
 
+    warn "Do not power off computer.  Updating firmware, this will take a few minutes..."
     flashrom $CONFIG_FLASHROM_OPTIONS -w /tmp/${CONFIG_BOARD}.rom 2>&1 \
       || die "$ROM: Flash failed"
   fi


### PR DESCRIPTION
Add a warning prior of calling flashrom reminding end user to not poweroff and wait while flashing operation finishes.

Message prior of version dependent flashrom output will now be :
> WARNING: Do not power off computer. Updating firmware, this will take a few minutes...

---

Reasoning, as per https://github.com/linuxboot/heads/pull/1753#issuecomment-2307255469:

> So on master with flashrom 1.3:
> - tested (DEBUG ON) https://output.circle-artifacts.com/output/job/78a45204-7736-4f87-bf5d-922b48469782/artifacts/0/build/x86/x230-hotp-maximized/heads-x230-hotp-maximized-v0.2.0-2282-g1e03e8c.zip
> - Scary, but ok:
> ![signal-2024-08-23-102929](https://github.com/user-attachments/assets/5f726b8f-cfb0-4dbe-8e47-bba32cdef831)
> 
> 
> Under this PR containing flashrom 1.4:
> - tested (DEBUG ON) https://output.circle-artifacts.com/output/job/31dce9e2-7216-4d90-9528-efd3d0ff6668/artifacts/0/build/x86/x230-hotp-maximized/heads-x230-hotp-maximized-v0.2.0-2290-g35b43b0.zip
> - Scary but not so ok:
> ![signal-2024-08-23-102615](https://github.com/user-attachments/assets/77dac31a-45e8-43ee-bbf8-4cf4ae10b351)