### PR TITLE
oem-factory-reset gui-init: fix whiptail_error segfaulting because selfcalling itself; fix typo in gui-init

### DIFF
--- a/initrd/bin/gui-init
+++ b/initrd/bin/gui-init
@@ -363,7 +363,7 @@ check_gpg_key()
     option=$(cat /tmp/whiptail)
     case "$option" in 
       g )
-        gpg-gui.sh && BG_COLOR_MAIN_MENU="normnal"
+        gpg-gui.sh && BG_COLOR_MAIN_MENU="normal"
         ;;
       i )
         skip_to_menu="true"

--- a/initrd/bin/oem-factory-reset
+++ b/initrd/bin/oem-factory-reset
@@ -62,7 +62,7 @@ die() {
     exit 1
 }
 
-whiptail_error() {
+local_whiptail_error() {
     local msg=$1
     if [ "$msg" = "" ]; then
         die "whiptail error: An error msg is required"
@@ -71,7 +71,7 @@ whiptail_error() {
 }
 
 whiptail_error_die() {
-    whiptail_error "$@"
+    local_whiptail_error "$@"
     die
 }
 
@@ -1111,7 +1111,7 @@ if [ "$GPG_GEN_KEY_IN_MEMORY" = "n" -o "$GPG_GEN_KEY_IN_MEMORY_COPY_TO_SMARTCARD
     echo -e "\nChecking for USB Security Dongle...\n"
     enable_usb
     if ! gpg --card-status >/dev/null 2>&1; then
-        whiptail_error "Can't access USB Security Dongle; \nPlease remove and reinsert, then press Enter."
+        local_whiptail_error "Can't access USB Security Dongle; \nPlease remove and reinsert, then press Enter."
         if ! gpg --card-status >/dev/null 2>/tmp/error; then
             ERROR=$(tail -n 1 /tmp/error | fold -s)
             whiptail_error_die "Unable to detect USB Security Dongle:\n\n${ERROR}"


### PR DESCRIPTION
fix bugs introduced by #1698:
- whiptail_error was self calling itself in case no usb security dongle was connected instead of asking the user to plug it in and try again
- whiptail_error and whiptail_warning are overrides of sourced /etc/gui_functions
  - therefore, whiptail_error calling whiptail_error was self calling passing wrong paramters and whiptail prompt was never showed.
  - fixed by renaming oem-factory-reset's whiptail_error into local_whiptail_error function and changing whiptail_error_die and the only place where this fonction was called directly

--- 

Superseeds #1777 

Addresses https://github.com/linuxboot/heads/issues/1395#issuecomment-2308014938 : thanks for reporting @arhabd

---

No need for review after testing, "emergency" bugfix