### PR TITLE
gui_functions: add newline after message telling user that automatic boot will happen unless interrupted

### DIFF
--- a/initrd/etc/gui_functions
+++ b/initrd/etc/gui_functions
@@ -6,8 +6,8 @@
 # continue with automatic boot, nonzero if user interrupted.
 pause_automatic_boot()
 {
-	if IFS= read -t "$CONFIG_AUTO_BOOT_TIMEOUT" -s -n 1 -p \
-		"Automatic boot in $CONFIG_AUTO_BOOT_TIMEOUT seconds unless interrupted by keypress... "; then
+	if IFS= read -t "$CONFIG_AUTO_BOOT_TIMEOUT" -s -n 1 -r -p \
+		$'Automatic boot in '"$CONFIG_AUTO_BOOT_TIMEOUT"$' seconds unless interrupted by keypress...\n'; then
 		return 1 # Interrupt automatic boot
 	fi
 	return 0 # Continue with automatic boot


### PR DESCRIPTION
Aesthetic fix. Otherwise interrupting default boot and next action write on same line.

@JonathonHall-Purism quick review. Approve & Merge when done!