### PR TITLE
qemu-coreboot-whiptail-tpm2 board: reenable DEBUG + TRACING

### DIFF
--- a/boards/qemu-coreboot-whiptail-tpm2/qemu-coreboot-whiptail-tpm2.config
+++ b/boards/qemu-coreboot-whiptail-tpm2/qemu-coreboot-whiptail-tpm2.config
@@ -17,10 +17,10 @@ CONFIG_LINUX_CONFIG=config/linux-qemu.config
 #export CONFIG_HAVE_GPG_KEY_BACKUP=y
 
 #Enable DEBUG output
-#export CONFIG_DEBUG_OUTPUT=y
-#export CONFIG_ENABLE_FUNCTION_TRACING_OUTPUT=y
+export CONFIG_DEBUG_OUTPUT=y
+export CONFIG_ENABLE_FUNCTION_TRACING_OUTPUT=y
 #Enable TPM2 pcap output under /tmp
-#export CONFIG_TPM2_CAPTURE_PCAP=y
+export CONFIG_TPM2_CAPTURE_PCAP=y
 
 #On-demand hardware support (modules.cpio)
 CONFIG_LINUX_USB=y


### PR DESCRIPTION
bugfix, was not supposed to be in non-debug in master.