### PR TITLE
init: add export BG_COLOR_MAIN_MENU="normal" so that media-scan, confiig-gui flash-gui etc can be called from Recovery shell 

### DIFF
--- a/initrd/init
+++ b/initrd/init
@@ -105,9 +105,11 @@ fi
 if [ -x /bin/fbwhiptail ]; then
 	export BG_COLOR_WARNING="${CONFIG_WARNING_BG_COLOR:-"--background-gradient 0 0 0 150 125 0"}"
 	export BG_COLOR_ERROR="${CONFIG_ERROR_BG_COLOR:-"--background-gradient 0 0 0 150 0 0"}"
+	export BG_COLOR_MAIN_MENU="normal"
 else
 	export TEXT_BG_COLOR_WARNING="${CONFIG_WARNING_TEXT_BG_COLOR:-"yellow"}"
 	export TEXT_BG_COLOR_ERROR="${CONFIG_ERROR_TEXT_BG_COLOR:-"red"}"
+	export BG_COLOR_MAIN_MENU="normal"
 fi
 
 if [ "$CONFIG_TPM" = "y" ]; then


### PR DESCRIPTION
gui-init which was sole exporter of BG_COLOR_MAIN_MENU

Fix bug introduced by https://github.com/linuxboot/heads/pull/1778