### PR TITLE
etc/ash_functions: remove TRACE_FUNC that cannot be used in ash, only under bash

### DIFF
--- a/initrd/etc/ash_functions
+++ b/initrd/etc/ash_functions
@@ -241,7 +241,6 @@ recovery() {
 	DEBUG "Board $CONFIG_BOARD - version $(fw_version)"
 
 	if [ "$CONFIG_TPM" = "y" ]; then
-		TRACE_FUNC
 		echo "TPM: Extending PCR[4] to prevent any further secret unsealing"
 		tpmr extend -ix 4 -ic recovery
 	fi


### PR DESCRIPTION
bugfix