### PR TITLE
bin/fetch_source_archive.sh: Add storage.puri.st mirror

### DIFF
--- a/bin/fetch_source_archive.sh
+++ b/bin/fetch_source_archive.sh
@@ -4,6 +4,7 @@ set -eo pipefail
 # Mirror URLs, make sure these end in slashes.
 BACKUP_MIRRORS=(
 	https://storage.puri.sm/heads-packages/
+	https://storage.puri.st/heads-packages/
 )
 
 usage()


### PR DESCRIPTION
storage.puri.st is an alternate host name for storage.puri.sm, in case there is another issue with the .sm name registration.