### PR TITLE
BUGFIX: targets/split_8mb4mb.mk Makefile: Make sure top/bottom/rom hash+size are always outputted in console+hashes.txt+sizes.txt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -245,7 +245,14 @@ $(board_build)/$(CB_UPDATE_PKG_FILE): $(board_build)/$(CB_OUTPUT_FILE)
 	cd "$(board_build)/update_pkg" && sha256sum "$(CB_OUTPUT_FILE)" >sha256sum.txt
 	cd "$(board_build)/update_pkg" && zip -9 "$@" "$(CB_OUTPUT_FILE)" sha256sum.txt
 
+# Only add the hash and size if split_8mb4mb.mk is not included
+ifeq ($(wildcard split_8mb4mb.mk),)
 all: $(board_build)/$(CB_OUTPUT_FILE) $(board_build)/$(CB_UPDATE_PKG_FILE)
+	@sha256sum $(board_build)/$(CB_OUTPUT_FILE) | tee -a "$(HASHES)"
+	@stat -c "%8s:%n" $(board_build)/$(CB_OUTPUT_FILE) | tee -a "$(SIZES)"
+else
+all: $(board_build)/$(CB_OUTPUT_FILE) $(board_build)/$(CB_UPDATE_PKG_FILE)
+endif
 endif
 endif
 

--- a/targets/split_8mb4mb.mk
+++ b/targets/split_8mb4mb.mk
@@ -7,12 +7,24 @@
 #
 # When flashing via an external programmer it is easiest to have
 # two separate files for these pieces.
-all: $(board_build)/heads-$(BOARD)-$(HEADS_GIT_VERSION)-bottom.rom
-$(board_build)/heads-$(BOARD)-$(HEADS_GIT_VERSION)-bottom.rom: $(board_build)/$(CB_OUTPUT_FILE)
-	$(call do,DD 8MB,$@,dd of=$@ if=$< bs=65536 count=128 skip=0 status=none)
-	@sha256sum $@ | tee -a "$(HASHES)"
+all: bottom top
 
-all: $(board_build)/heads-$(BOARD)-$(HEADS_GIT_VERSION)-top.rom
-$(board_build)/heads-$(BOARD)-$(HEADS_GIT_VERSION)-top.rom: $(board_build)/$(CB_OUTPUT_FILE)
-	$(call do,DD 4MB,$@,dd of=$@ if=$< bs=65536 count=64 skip=128 status=none)
-	@sha256sum $@ | tee -a "$(HASHES)"
+bottom: $(board_build)/heads-$(BOARD)-$(HEADS_GIT_VERSION)-bottom.rom
+
+$(board_build)/heads-$(BOARD)-$(HEADS_GIT_VERSION)-bottom.rom: $(board_build)/$(CB_OUTPUT_FILE) FORCE
+	@rm -f $(board_build)/heads-$(BOARD)-$(HEADS_GIT_VERSION)-bottom.rom
+	$(call do,DD 8MB,$(board_build)/heads-$(BOARD)-$(HEADS_GIT_VERSION)-bottom.rom,dd if=$< of=$@ bs=65536 count=128 skip=0 status=none)
+	@sha256sum $(board_build)/heads-$(BOARD)-$(HEADS_GIT_VERSION)-bottom.rom | tee -a "$(HASHES)"
+	@stat -c "%8s:%n" $(board_build)/heads-$(BOARD)-$(HEADS_GIT_VERSION)-bottom.rom | tee -a "$(SIZES)"
+
+top: $(board_build)/heads-$(BOARD)-$(HEADS_GIT_VERSION)-top.rom
+
+$(board_build)/heads-$(BOARD)-$(HEADS_GIT_VERSION)-top.rom: $(board_build)/$(CB_OUTPUT_FILE) FORCE
+	@rm -f $(board_build)/heads-$(BOARD)-$(HEADS_GIT_VERSION)-top.rom
+	$(call do,DD 4MB,$(board_build)/heads-$(BOARD)-$(HEADS_GIT_VERSION)-top.rom,dd if=$< of=$@ bs=65536 count=64 skip=128 status=none)
+	@sha256sum $(board_build)/heads-$(BOARD)-$(HEADS_GIT_VERSION)-top.rom | tee -a "$(HASHES)"
+	@stat -c "%8s:%n" $(board_build)/heads-$(BOARD)-$(HEADS_GIT_VERSION)-top.rom | tee -a "$(SIZES)"
+
+FORCE:
+
+.PHONY: all bottom top FORCE


### PR DESCRIPTION
fix https://github.com/linuxboot/heads/issues/1534