### PR TITLE
boards/qemu*: add "prod" variants, not built by CircleCI as of now, to test Heads prod console output

### DIFF
--- a/boards/qemu-coreboot-fbwhiptail-tpm1-hotp-prod/qemu-coreboot-fbwhiptail-tpm1-hotp-prod.config
+++ b/boards/qemu-coreboot-fbwhiptail-tpm1-hotp-prod/qemu-coreboot-fbwhiptail-tpm1-hotp-prod.config
@@ -1,0 +1,97 @@
+# Configuration for building a coreboot ROM that works in
+# the qemu emulator in console mode thanks to Whiptail
+#
+# TPM can be used with a qemu software TPM (TIS, 1.2).  A Librem Key or
+# Nitrokey Pro can also be used by forwarding the USB device from the host to
+# the VM.
+export CONFIG_COREBOOT=y
+export CONFIG_COREBOOT_VERSION=24.02.01
+export CONFIG_LINUX_VERSION=6.1.8
+
+CONFIG_COREBOOT_CONFIG=config/coreboot-qemu-tpm1.config
+CONFIG_LINUX_CONFIG=config/linux-qemu.config
+
+#Enable only one RESTRICTED/BASIC boot modes below to test them manually (we cannot inject config under QEMU (no internal flashing)
+#export CONFIG_RESTRICTED_BOOT=y
+#export CONFIG_BASIC=y
+
+#Enable HAVE_GPG_KEY_BACKUP to test GPG key backup drive (we cannot inject config under QEMU (no internal flashing))
+#export CONFIG_HAVE_GPG_KEY_BACKUP=y
+
+#Enable DEBUG output
+#export CONFIG_DEBUG_OUTPUT=y
+#export CONFIG_ENABLE_FUNCTION_TRACING_OUTPUT=y
+#Enable TPM2 pcap output under /tmp
+#export CONFIG_TPM2_CAPTURE_PCAP=y
+
+#On-demand hardware support (modules.cpio)
+CONFIG_LINUX_USB=y
+CONFIG_LINUX_E1000=y
+#CONFIG_MOBILE_TETHERING=y
+#Runtime on-demand additional hardware support (modules.cpio)
+export CONFIG_LINUX_USB_COMPANION_CONTROLLER=y
+
+
+
+#Modules packed into tools.cpio
+ifeq "$(CONFIG_UROOT)" "y"
+CONFIG_BUSYBOX=n
+else
+#Modules packed into tools.cpio
+CONFIG_CRYPTSETUP2=y
+CONFIG_FLASHPROG=y
+CONFIG_FLASHTOOLS=y
+CONFIG_GPG2=y
+CONFIG_KEXEC=y
+CONFIG_UTIL_LINUX=y
+CONFIG_LVM2=y
+CONFIG_MBEDTLS=y
+CONFIG_PCIUTILS=y
+#Runtime tools to write to MSR
+#CONFIG_MSRTOOLS=y
+#Remote attestation support
+# TPM2 requirements
+#CONFIG_TPM2_TSS=y
+#CONFIG_OPENSSL=y
+#Remote Attestation common tools
+CONFIG_POPT=y
+CONFIG_QRENCODE=y
+CONFIG_TPMTOTP=y
+#HOTP based remote attestation for supported USB Security dongle
+#With/Without TPM support
+CONFIG_HOTPKEY=y
+#Nitrokey Storage admin tool (deprecated)
+#CONFIG_NKSTORECLI=n
+#GUI Support
+#Console based Whiptail support(Console based, no FB):
+#CONFIG_SLANG=y
+#CONFIG_NEWT=y
+#FBWhiptail based (Graphical):
+CONFIG_CAIRO=y
+CONFIG_FBWHIPTAIL=y
+#Additional tools (tools.cpio):
+#SSH server (requires ethernet drivers, eg: CONFIG_LINUX_E1000E)
+CONFIG_DROPBEAR=y
+endif
+
+#Runtime configuration
+#Automatically boot if HOTP is valid
+export CONFIG_AUTO_BOOT_TIMEOUT=5
+#TPM2 requirements
+#export CONFIG_TPM2_TOOLS=y
+#export CONFIG_PRIMARY_KEY_TYPE=ecc
+#TPM1 requirements
+export CONFIG_TPM=y
+export CONFIG_BOOTSCRIPT=/bin/gui-init
+#text-based original init:
+#export CONFIG_BOOTSCRIPT=/bin/generic-init
+export CONFIG_BOOT_REQ_HASH=n
+export CONFIG_BOOT_REQ_ROLLBACK=n
+export CONFIG_BOOT_RECOVERY_SERIAL="/dev/ttyS0"
+export CONFIG_BOOT_KERNEL_ADD="console=ttyS0 console=tty systemd.zram=0"
+export CONFIG_BOOT_KERNEL_REMOVE="quiet rhgb splash"
+export CONFIG_BOARD_NAME="qemu-coreboot-fbwhiptail-tpm1-hotp"
+#export CONFIG_FLASH_OPTIONS="flashprog --progress --programmer internal"
+export CONFIG_AUTO_BOOT_TIMEOUT=5
+
+BOARD_TARGETS := qemu

--- a/boards/qemu-coreboot-fbwhiptail-tpm1-prod/qemu-coreboot-fbwhiptail-tpm1-prod.config
+++ b/boards/qemu-coreboot-fbwhiptail-tpm1-prod/qemu-coreboot-fbwhiptail-tpm1-prod.config
@@ -1,0 +1,95 @@
+# Configuration for building a coreboot ROM that works in
+# the qemu emulator in console mode thanks to Whiptail
+#
+# TPM can be used with a qemu software TPM (TIS, 1.2).
+export CONFIG_COREBOOT=y
+export CONFIG_COREBOOT_VERSION=24.02.01
+export CONFIG_LINUX_VERSION=6.1.8
+
+CONFIG_COREBOOT_CONFIG=config/coreboot-qemu-tpm2.config
+CONFIG_LINUX_CONFIG=config/linux-qemu.config
+
+#Enable only one RESTRICTED/BASIC boot modes below to test them manually (we cannot inject config under QEMU (no internal flashing)
+#export CONFIG_RESTRICTED_BOOT=y
+#export CONFIG_BASIC=y
+
+#Enable HAVE_GPG_KEY_BACKUP to test GPG key backup drive (we cannot inject config under QEMU (no internal flashing))
+#export CONFIG_HAVE_GPG_KEY_BACKUP=y
+
+#Enable DEBUG output
+#export CONFIG_DEBUG_OUTPUT=y
+#export CONFIG_ENABLE_FUNCTION_TRACING_OUTPUT=y
+#Enable TPM2 pcap output under /tmp
+#export CONFIG_TPM2_CAPTURE_PCAP=y
+
+#On-demand hardware support (modules.cpio)
+CONFIG_LINUX_USB=y
+CONFIG_LINUX_E1000=y
+#CONFIG_MOBILE_TETHERING=y
+#Runtime on-demand additional hardware support (modules.cpio)
+export CONFIG_LINUX_USB_COMPANION_CONTROLLER=y
+
+
+
+#Modules packed into tools.cpio
+ifeq "$(CONFIG_UROOT)" "y"
+CONFIG_BUSYBOX=n
+else
+#Modules packed into tools.cpio
+CONFIG_CRYPTSETUP2=y
+CONFIG_FLASHPROG=y
+CONFIG_FLASHTOOLS=y
+CONFIG_GPG2=y
+CONFIG_KEXEC=y
+CONFIG_UTIL_LINUX=y
+CONFIG_LVM2=y
+CONFIG_MBEDTLS=y
+CONFIG_PCIUTILS=y
+#Runtime tools to write to MSR
+CONFIG_MSRTOOLS=y
+#Remote attestation support
+# TPM2 requirements
+#CONFIG_TPM2_TSS=y
+#CONFIG_OPENSSL=y
+#Remote Attestation common tools
+CONFIG_POPT=y
+CONFIG_QRENCODE=y
+CONFIG_TPMTOTP=y
+#HOTP based remote attestation for supported USB Security dongle
+#With/Without TPM support
+#CONFIG_HOTPKEY=y
+#Nitrokey Storage admin tool (deprecated)
+#CONFIG_NKSTORECLI=n
+#GUI Support
+#Console based Whiptail support(Console based, no FB):
+#CONFIG_SLANG=y
+#CONFIG_NEWT=y
+#FBWhiptail based (Graphical):
+CONFIG_CAIRO=y
+CONFIG_FBWHIPTAIL=y
+#Additional tools (tools.cpio):
+#SSH server (requires ethernet drivers, eg: CONFIG_LINUX_E1000E)
+CONFIG_DROPBEAR=y
+endif
+
+#Runtime configuration
+#Automatically boot if HOTP is valid
+export CONFIG_AUTO_BOOT_TIMEOUT=5
+#TPM2 requirements
+#export CONFIG_TPM2_TOOLS=y
+#export CONFIG_PRIMARY_KEY_TYPE=ecc
+#TPM1 requirements
+export CONFIG_TPM=y
+export CONFIG_BOOTSCRIPT=/bin/gui-init
+#text-based original init:
+#export CONFIG_BOOTSCRIPT=/bin/generic-init
+export CONFIG_BOOT_REQ_HASH=n
+export CONFIG_BOOT_REQ_ROLLBACK=n
+export CONFIG_BOOT_RECOVERY_SERIAL="/dev/ttyS0"
+export CONFIG_BOOT_KERNEL_ADD="console=ttyS0 console=tty systemd.zram=0"
+export CONFIG_BOOT_KERNEL_REMOVE="quiet rhgb splash"
+export CONFIG_BOARD_NAME="qemu-coreboot-fbwhiptail-tpm1"
+#export CONFIG_FLASH_OPTIONS="flashprog --progress --programmer internal"
+#export CONFIG_AUTO_BOOT_TIMEOUT=5
+
+BOARD_TARGETS := qemu

--- a/boards/qemu-coreboot-fbwhiptail-tpm2-hotp-prod/qemu-coreboot-fbwhiptail-tpm2-hotp-prod.config
+++ b/boards/qemu-coreboot-fbwhiptail-tpm2-hotp-prod/qemu-coreboot-fbwhiptail-tpm2-hotp-prod.config
@@ -1,0 +1,96 @@
+# Configuration for building a coreboot ROM that works in
+# the qemu emulator in graphical mode thanks to FBWhiptail
+# This version requires a supported HOTP Security dongle (Nitrokey Pro/Storage or Librem Key)
+#
+# TPM can be used with a qemu software TPM (TIS, 2.0).
+export CONFIG_COREBOOT=y
+export CONFIG_COREBOOT_VERSION=24.02.01
+export CONFIG_LINUX_VERSION=6.1.8
+
+CONFIG_COREBOOT_CONFIG=config/coreboot-qemu-tpm2.config
+CONFIG_LINUX_CONFIG=config/linux-qemu.config
+
+#Enable only one RESTRICTED/BASIC boot modes below to test them manually (we cannot inject config under QEMU (no internal flashing)
+#export CONFIG_RESTRICTED_BOOT=y
+#export CONFIG_BASIC=y
+
+#Enable HAVE_GPG_KEY_BACKUP to test GPG key backup drive (we cannot inject config under QEMU (no internal flashing))
+#export CONFIG_HAVE_GPG_KEY_BACKUP=y
+
+#Enable DEBUG output
+#export CONFIG_DEBUG_OUTPUT=y
+#export CONFIG_ENABLE_FUNCTION_TRACING_OUTPUT=y
+#Enable TPM2 pcap output under /tmp
+#export CONFIG_TPM2_CAPTURE_PCAP=y
+
+#On-demand hardware support (modules.cpio)
+CONFIG_LINUX_USB=y
+CONFIG_LINUX_E1000=y
+#CONFIG_MOBILE_TETHERING=y
+#Runtime on-demand additional hardware support (modules.cpio)
+export CONFIG_LINUX_USB_COMPANION_CONTROLLER=y
+
+
+
+#Modules packed into tools.cpio
+ifeq "$(CONFIG_UROOT)" "y"
+CONFIG_BUSYBOX=n
+else
+#Modules packed into tools.cpio
+CONFIG_CRYPTSETUP2=y
+CONFIG_FLASHPROG=y
+CONFIG_FLASHTOOLS=y
+CONFIG_GPG2=y
+CONFIG_KEXEC=y
+CONFIG_UTIL_LINUX=y
+CONFIG_LVM2=y
+CONFIG_MBEDTLS=y
+CONFIG_PCIUTILS=y
+#Runtime tools to write to MSR
+CONFIG_MSRTOOLS=y
+#Remote attestation support
+# TPM2 requirements
+CONFIG_TPM2_TSS=y
+CONFIG_OPENSSL=y
+#Remote Attestation common tools
+CONFIG_POPT=y
+CONFIG_QRENCODE=y
+CONFIG_TPMTOTP=y
+#HOTP based remote attestation for supported USB Security dongle
+#With/Without TPM support
+CONFIG_HOTPKEY=y
+#Nitrokey Storage admin tool (deprecated)
+#CONFIG_NKSTORECLI=n
+#GUI Support
+#Console based Whiptail support(Console based, no FB):
+#CONFIG_SLANG=y
+#CONFIG_NEWT=y
+#FBWhiptail based (Graphical):
+CONFIG_CAIRO=y
+CONFIG_FBWHIPTAIL=y
+#Additional tools (tools.cpio):
+#SSH server (requires ethernet drivers, eg: CONFIG_LINUX_E1000E)
+CONFIG_DROPBEAR=y
+endif
+
+#Runtime configuration
+#Automatically boot if HOTP is valid
+export CONFIG_AUTO_BOOT_TIMEOUT=5
+#TPM2 requirements
+export CONFIG_TPM2_TOOLS=y
+export CONFIG_PRIMARY_KEY_TYPE=ecc
+#TPM1 requirements
+#export CONFIG_TPM=y
+export CONFIG_BOOTSCRIPT=/bin/gui-init
+#text-based original init:
+#export CONFIG_BOOTSCRIPT=/bin/generic-init
+export CONFIG_BOOT_REQ_HASH=n
+export CONFIG_BOOT_REQ_ROLLBACK=n
+export CONFIG_BOOT_RECOVERY_SERIAL="/dev/ttyS0"
+export CONFIG_BOOT_KERNEL_ADD="console=ttyS0 console=tty systemd.zram=0"
+export CONFIG_BOOT_KERNEL_REMOVE="quiet rhgb splash"
+export CONFIG_BOARD_NAME="qemu-coreboot-fbwhiptail-tpm2-hotp"
+#export CONFIG_FLASH_OPTIONS="flashprog --progress --programmer internal"
+export CONFIG_AUTO_BOOT_TIMEOUT=5
+
+BOARD_TARGETS := qemu

--- a/boards/qemu-coreboot-fbwhiptail-tpm2-prod/qemu-coreboot-fbwhiptail-tpm2-prod.config
+++ b/boards/qemu-coreboot-fbwhiptail-tpm2-prod/qemu-coreboot-fbwhiptail-tpm2-prod.config
@@ -1,0 +1,95 @@
+# Configuration for building a coreboot ROM that works in
+# the qemu emulator in graphical mode thanks to FBWhiptail
+#
+# TPM can be used with a qemu software TPM (TIS, 2.0).
+export CONFIG_COREBOOT=y
+export CONFIG_COREBOOT_VERSION=24.02.01
+export CONFIG_LINUX_VERSION=6.1.8
+
+CONFIG_COREBOOT_CONFIG=config/coreboot-qemu-tpm2.config
+CONFIG_LINUX_CONFIG=config/linux-qemu.config
+
+#Enable only one RESTRICTED/BASIC boot modes below to test them manually (we cannot inject config under QEMU (no internal flashing)
+#export CONFIG_RESTRICTED_BOOT=y
+#export CONFIG_BASIC=y
+
+#Enable HAVE_GPG_KEY_BACKUP to test GPG key backup drive (we cannot inject config under QEMU (no internal flashing))
+#export CONFIG_HAVE_GPG_KEY_BACKUP=y
+
+#Enable DEBUG output
+#export CONFIG_DEBUG_OUTPUT=y
+#export CONFIG_ENABLE_FUNCTION_TRACING_OUTPUT=y
+#Enable TPM2 pcap output under /tmp
+#export CONFIG_TPM2_CAPTURE_PCAP=y
+
+#On-demand hardware support (modules.cpio)
+CONFIG_LINUX_USB=y
+CONFIG_LINUX_E1000=y
+#CONFIG_MOBILE_TETHERING=y
+#Runtime on-demand additional hardware support (modules.cpio)
+export CONFIG_LINUX_USB_COMPANION_CONTROLLER=y
+
+
+
+#Modules packed into tools.cpio
+ifeq "$(CONFIG_UROOT)" "y"
+CONFIG_BUSYBOX=n
+else
+#Modules packed into tools.cpio
+CONFIG_CRYPTSETUP2=y
+CONFIG_FLASHPROG=y
+CONFIG_FLASHTOOLS=y
+CONFIG_GPG2=y
+CONFIG_KEXEC=y
+CONFIG_UTIL_LINUX=y
+CONFIG_LVM2=y
+CONFIG_MBEDTLS=y
+CONFIG_PCIUTILS=y
+#Runtime tools to write to MSR
+CONFIG_MSRTOOLS=y
+#Remote attestation support
+# TPM2 requirements
+CONFIG_TPM2_TSS=y
+CONFIG_OPENSSL=y
+#Remote Attestation common tools
+CONFIG_POPT=y
+CONFIG_QRENCODE=y
+CONFIG_TPMTOTP=y
+#HOTP based remote attestation for supported USB Security dongle
+#With/Without TPM support
+#CONFIG_HOTPKEY=y
+#Nitrokey Storage admin tool (deprecated)
+#CONFIG_NKSTORECLI=n
+#GUI Support
+#Console based Whiptail support(Console based, no FB):
+#CONFIG_SLANG=y
+#CONFIG_NEWT=y
+#FBWhiptail based (Graphical):
+CONFIG_CAIRO=y
+CONFIG_FBWHIPTAIL=y
+#Additional tools (tools.cpio):
+#SSH server (requires ethernet drivers, eg: CONFIG_LINUX_E1000E)
+CONFIG_DROPBEAR=y
+endif
+
+#Runtime configuration
+#Automatically boot if HOTP is valid
+export CONFIG_AUTO_BOOT_TIMEOUT=5
+#TPM2 requirements
+export CONFIG_TPM2_TOOLS=y
+export CONFIG_PRIMARY_KEY_TYPE=ecc
+#TPM1 requirements
+#export CONFIG_TPM=y
+export CONFIG_BOOTSCRIPT=/bin/gui-init
+#text-based original init:
+#export CONFIG_BOOTSCRIPT=/bin/generic-init
+export CONFIG_BOOT_REQ_HASH=n
+export CONFIG_BOOT_REQ_ROLLBACK=n
+export CONFIG_BOOT_RECOVERY_SERIAL="/dev/ttyS0"
+export CONFIG_BOOT_KERNEL_ADD="console=ttyS0 console=tty systemd.zram=0"
+export CONFIG_BOOT_KERNEL_REMOVE="quiet rhgb splash"
+export CONFIG_BOARD_NAME="qemu-coreboot-fbwhiptail-tpm2"
+#export CONFIG_FLASH_OPTIONS="flashprog --progress --programmer internal"
+#export CONFIG_AUTO_BOOT_TIMEOUT=5
+
+BOARD_TARGETS := qemu

--- a/boards/qemu-coreboot-whiptail-tpm1-hotp-prod/qemu-coreboot-whiptail-tpm1-hotp-prod.config
+++ b/boards/qemu-coreboot-whiptail-tpm1-hotp-prod/qemu-coreboot-whiptail-tpm1-hotp-prod.config
@@ -1,0 +1,97 @@
+# Configuration for building a coreboot ROM that works in
+# the qemu emulator in console mode thanks to Whiptail
+#
+# TPM can be used with a qemu software TPM (TIS, 1.2).  A Librem Key or
+# Nitrokey Pro can also be used by forwarding the USB device from the host to
+# the VM.
+export CONFIG_COREBOOT=y
+export CONFIG_COREBOOT_VERSION=24.02.01
+export CONFIG_LINUX_VERSION=6.1.8
+
+CONFIG_COREBOOT_CONFIG=config/coreboot-qemu-tpm1.config
+CONFIG_LINUX_CONFIG=config/linux-qemu.config
+
+#Enable only one RESTRICTED/BASIC boot modes below to test them manually (we cannot inject config under QEMU (no internal flashing)
+#export CONFIG_RESTRICTED_BOOT=y
+#export CONFIG_BASIC=y
+
+#Enable HAVE_GPG_KEY_BACKUP to test GPG key backup drive (we cannot inject config under QEMU (no internal flashing))
+#export CONFIG_HAVE_GPG_KEY_BACKUP=y
+
+#Enable DEBUG output
+#export CONFIG_DEBUG_OUTPUT=y
+#export CONFIG_ENABLE_FUNCTION_TRACING_OUTPUT=y
+#Enable TPM2 pcap output under /tmp
+#export CONFIG_TPM2_CAPTURE_PCAP=y
+
+#On-demand hardware support (modules.cpio)
+CONFIG_LINUX_USB=y
+CONFIG_LINUX_E1000=y
+#CONFIG_MOBILE_TETHERING=y
+#Runtime on-demand additional hardware support (modules.cpio)
+export CONFIG_LINUX_USB_COMPANION_CONTROLLER=y
+
+
+
+#Modules packed into tools.cpio
+ifeq "$(CONFIG_UROOT)" "y"
+CONFIG_BUSYBOX=n
+else
+#Modules packed into tools.cpio
+CONFIG_CRYPTSETUP2=y
+CONFIG_FLASHPROG=y
+CONFIG_FLASHTOOLS=y
+CONFIG_GPG2=y
+CONFIG_KEXEC=y
+CONFIG_UTIL_LINUX=y
+CONFIG_LVM2=y
+CONFIG_MBEDTLS=y
+CONFIG_PCIUTILS=y
+#Runtime tools to write to MSR
+CONFIG_MSRTOOLS=y
+#Remote attestation support
+# TPM2 requirements
+#CONFIG_TPM2_TSS=y
+#CONFIG_OPENSSL=y
+#Remote Attestation common tools
+CONFIG_POPT=y
+CONFIG_QRENCODE=y
+CONFIG_TPMTOTP=y
+#HOTP based remote attestation for supported USB Security dongle
+#With/Without TPM support
+CONFIG_HOTPKEY=y
+#Nitrokey Storage admin tool (deprecated)
+#CONFIG_NKSTORECLI=n
+#GUI Support
+#Console based Whiptail support(Console based, no FB):
+CONFIG_SLANG=y
+CONFIG_NEWT=y
+#FBWhiptail based (Graphical):
+#CONFIG_CAIRO=y
+#CONFIG_FBWHIPTAIL=y
+#Additional tools (tools.cpio):
+#SSH server (requires ethernet drivers, eg: CONFIG_LINUX_E1000E)
+CONFIG_DROPBEAR=y
+endif
+
+#Runtime configuration
+#Automatically boot if HOTP is valid
+export CONFIG_AUTO_BOOT_TIMEOUT=5
+#TPM2 requirements
+#export CONFIG_TPM2_TOOLS=y
+#export CONFIG_PRIMARY_KEY_TYPE=ecc
+#TPM1 requirements
+export CONFIG_TPM=y
+export CONFIG_BOOTSCRIPT=/bin/gui-init
+#text-based original init:
+#export CONFIG_BOOTSCRIPT=/bin/generic-init
+export CONFIG_BOOT_REQ_HASH=n
+export CONFIG_BOOT_REQ_ROLLBACK=n
+export CONFIG_BOOT_RECOVERY_SERIAL="/dev/ttyS0"
+export CONFIG_BOOT_KERNEL_ADD="console=ttyS0 console=tty systemd.zram=0"
+export CONFIG_BOOT_KERNEL_REMOVE="quiet rhgb splash"
+export CONFIG_BOARD_NAME="qemu-coreboot-whiptail-tpm1-hotp"
+#export CONFIG_FLASH_OPTIONS="flashprog --progress --programmer internal"
+export CONFIG_AUTO_BOOT_TIMEOUT=5
+
+BOARD_TARGETS := qemu

--- a/boards/qemu-coreboot-whiptail-tpm1-prod/qemu-coreboot-whiptail-tpm1-prod.config
+++ b/boards/qemu-coreboot-whiptail-tpm1-prod/qemu-coreboot-whiptail-tpm1-prod.config
@@ -1,0 +1,95 @@
+# Configuration for building a coreboot ROM that works in
+# the qemu emulator in console mode thanks to Whiptail
+#
+# TPM can be used with a qemu software TPM (TIS, 1.2).
+export CONFIG_COREBOOT=y
+export CONFIG_COREBOOT_VERSION=24.02.01
+export CONFIG_LINUX_VERSION=6.1.8
+
+CONFIG_COREBOOT_CONFIG=config/coreboot-qemu-tpm1.config
+CONFIG_LINUX_CONFIG=config/linux-qemu.config
+
+#Enable only one RESTRICTED/BASIC boot modes below to test them manually (we cannot inject config under QEMU (no internal flashing)
+#export CONFIG_RESTRICTED_BOOT=y
+#export CONFIG_BASIC=y
+
+#Enable HAVE_GPG_KEY_BACKUP to test GPG key backup drive (we cannot inject config under QEMU (no internal flashing))
+#export CONFIG_HAVE_GPG_KEY_BACKUP=y
+
+#Enable DEBUG output
+#export CONFIG_DEBUG_OUTPUT=y
+#export CONFIG_ENABLE_FUNCTION_TRACING_OUTPUT=y
+#Enable TPM2 pcap output under /tmp
+#export CONFIG_TPM2_CAPTURE_PCAP=y
+
+#On-demand hardware support (modules.cpio)
+CONFIG_LINUX_USB=y
+CONFIG_LINUX_E1000=y
+#CONFIG_MOBILE_TETHERING=y
+#Runtime on-demand additional hardware support (modules.cpio)
+export CONFIG_LINUX_USB_COMPANION_CONTROLLER=y
+
+
+
+#Modules packed into tools.cpio
+ifeq "$(CONFIG_UROOT)" "y"
+CONFIG_BUSYBOX=n
+else
+#Modules packed into tools.cpio
+CONFIG_CRYPTSETUP2=y
+CONFIG_FLASHPROG=y
+CONFIG_FLASHTOOLS=y
+CONFIG_GPG2=y
+CONFIG_KEXEC=y
+CONFIG_UTIL_LINUX=y
+CONFIG_LVM2=y
+CONFIG_MBEDTLS=y
+CONFIG_PCIUTILS=y
+#Runtime tools to write to MSR
+CONFIG_MSRTOOLS=y
+#Remote attestation support
+# TPM2 requirements
+#CONFIG_TPM2_TSS=y
+#CONFIG_OPENSSL=y
+#Remote Attestation common tools
+CONFIG_POPT=y
+CONFIG_QRENCODE=y
+CONFIG_TPMTOTP=y
+#HOTP based remote attestation for supported USB Security dongle
+#With/Without TPM support
+#CONFIG_HOTPKEY=y
+#Nitrokey Storage admin tool (deprecated)
+#CONFIG_NKSTORECLI=n
+#GUI Support
+#Console based Whiptail support(Console based, no FB):
+CONFIG_SLANG=y
+CONFIG_NEWT=y
+#FBWhiptail based (Graphical):
+#CONFIG_CAIRO=y
+#CONFIG_FBWHIPTAIL=y
+#Additional tools (tools.cpio):
+#SSH server (requires ethernet drivers, eg: CONFIG_LINUX_E1000E)
+CONFIG_DROPBEAR=y
+endif
+
+#Runtime configuration
+#Automatically boot if HOTP is valid
+export CONFIG_AUTO_BOOT_TIMEOUT=5
+#TPM2 requirements
+#export CONFIG_TPM2_TOOLS=y
+#export CONFIG_PRIMARY_KEY_TYPE=ecc
+#TPM1 requirements
+export CONFIG_TPM=y
+export CONFIG_BOOTSCRIPT=/bin/gui-init
+#text-based original init:
+#export CONFIG_BOOTSCRIPT=/bin/generic-init
+export CONFIG_BOOT_REQ_HASH=n
+export CONFIG_BOOT_REQ_ROLLBACK=n
+export CONFIG_BOOT_RECOVERY_SERIAL="/dev/ttyS0"
+export CONFIG_BOOT_KERNEL_ADD="console=ttyS0 console=tty systemd.zram=0"
+export CONFIG_BOOT_KERNEL_REMOVE="quiet rhgb splash"
+export CONFIG_BOARD_NAME="qemu-coreboot-whiptail-tpm1"
+#export CONFIG_FLASH_OPTIONS="flashprog --progress --programmer internal"
+#export CONFIG_AUTO_BOOT_TIMEOUT=5
+
+BOARD_TARGETS := qemu

--- a/boards/qemu-coreboot-whiptail-tpm2-hotp-prod/qemu-coreboot-whiptail-tpm2-hotp-prod.config
+++ b/boards/qemu-coreboot-whiptail-tpm2-hotp-prod/qemu-coreboot-whiptail-tpm2-hotp-prod.config
@@ -1,0 +1,96 @@
+# Configuration for building a coreboot ROM that works in
+# the qemu emulator in console mode thanks to Whiptail
+# This version requires a supported HOTP Security dongle (Nitrokey Pro/Storage or Librem Key)
+#
+# TPM can be used with a qemu software TPM (TIS, 2.0).
+export CONFIG_COREBOOT=y
+export CONFIG_COREBOOT_VERSION=24.02.01
+export CONFIG_LINUX_VERSION=6.1.8
+
+CONFIG_COREBOOT_CONFIG=config/coreboot-qemu-tpm2.config
+CONFIG_LINUX_CONFIG=config/linux-qemu.config
+
+#Enable only one RESTRICTED/BASIC boot modes below to test them manually (we cannot inject config under QEMU (no internal flashing)
+#export CONFIG_RESTRICTED_BOOT=y
+#export CONFIG_BASIC=y
+
+#Enable HAVE_GPG_KEY_BACKUP to test GPG key backup drive (we cannot inject config under QEMU (no internal flashing))
+#export CONFIG_HAVE_GPG_KEY_BACKUP=y
+
+#Enable DEBUG output
+#export CONFIG_DEBUG_OUTPUT=y
+#export CONFIG_ENABLE_FUNCTION_TRACING_OUTPUT=y
+#Enable TPM2 pcap output under /tmp
+#export CONFIG_TPM2_CAPTURE_PCAP=y
+
+#On-demand hardware support (modules.cpio)
+CONFIG_LINUX_USB=y
+CONFIG_LINUX_E1000=y
+#CONFIG_MOBILE_TETHERING=y
+#Runtime on-demand additional hardware support (modules.cpio)
+export CONFIG_LINUX_USB_COMPANION_CONTROLLER=y
+
+
+
+#Modules packed into tools.cpio
+ifeq "$(CONFIG_UROOT)" "y"
+CONFIG_BUSYBOX=n
+else
+#Modules packed into tools.cpio
+CONFIG_CRYPTSETUP2=y
+CONFIG_FLASHPROG=y
+CONFIG_FLASHTOOLS=y
+CONFIG_GPG2=y
+CONFIG_KEXEC=y
+CONFIG_UTIL_LINUX=y
+CONFIG_LVM2=y
+CONFIG_MBEDTLS=y
+CONFIG_PCIUTILS=y
+#Runtime tools to write to MSR
+#CONFIG_MSRTOOLS=y
+#Remote attestation support
+# TPM2 requirements
+CONFIG_TPM2_TSS=y
+CONFIG_OPENSSL=y
+#Remote Attestation common tools
+CONFIG_POPT=y
+CONFIG_QRENCODE=y
+CONFIG_TPMTOTP=y
+#HOTP based remote attestation for supported USB Security dongle
+#With/Without TPM support
+CONFIG_HOTPKEY=y
+#Nitrokey Storage admin tool (deprecated)
+#CONFIG_NKSTORECLI=n
+#GUI Support
+#Console based Whiptail support(Console based, no FB):
+CONFIG_SLANG=y
+CONFIG_NEWT=y
+#FBWhiptail based (Graphical):
+#CONFIG_CAIRO=y
+#CONFIG_FBWHIPTAIL=y
+#Additional tools (tools.cpio):
+#SSH server (requires ethernet drivers, eg: CONFIG_LINUX_E1000E)
+CONFIG_DROPBEAR=y
+endif
+
+#Runtime configuration
+#Automatically boot if HOTP is valid
+export CONFIG_AUTO_BOOT_TIMEOUT=5
+#TPM2 requirements
+export CONFIG_TPM2_TOOLS=y
+export CONFIG_PRIMARY_KEY_TYPE=ecc
+#TPM1 requirements
+#export CONFIG_TPM=y
+export CONFIG_BOOTSCRIPT=/bin/gui-init
+#text-based original init:
+#export CONFIG_BOOTSCRIPT=/bin/generic-init
+export CONFIG_BOOT_REQ_HASH=n
+export CONFIG_BOOT_REQ_ROLLBACK=n
+export CONFIG_BOOT_RECOVERY_SERIAL="/dev/ttyS0"
+export CONFIG_BOOT_KERNEL_ADD="console=ttyS0 console=tty systemd.zram=0"
+export CONFIG_BOOT_KERNEL_REMOVE="quiet rhgb splash"
+export CONFIG_BOARD_NAME="qemu-coreboot-whiptail-tpm2-hotp"
+#export CONFIG_FLASH_OPTIONS="flashprog --progress --programmer internal"
+export CONFIG_AUTO_BOOT_TIMEOUT=5
+
+BOARD_TARGETS := qemu

--- a/boards/qemu-coreboot-whiptail-tpm2-prod/qemu-coreboot-whiptail-tpm2-prod.config
+++ b/boards/qemu-coreboot-whiptail-tpm2-prod/qemu-coreboot-whiptail-tpm2-prod.config
@@ -1,0 +1,95 @@
+# Configuration for building a coreboot ROM that works in
+# the qemu emulator in console mode thanks to Whiptail
+#
+# TPM can be used with a qemu software TPM (TIS, 2.0).
+export CONFIG_COREBOOT=y
+export CONFIG_COREBOOT_VERSION=24.02.01
+export CONFIG_LINUX_VERSION=6.1.8
+
+CONFIG_COREBOOT_CONFIG=config/coreboot-qemu-tpm2.config
+CONFIG_LINUX_CONFIG=config/linux-qemu.config
+
+#Enable only one RESTRICTED/BASIC boot modes below to test them manually (we cannot inject config under QEMU (no internal flashing)
+#export CONFIG_RESTRICTED_BOOT=y
+#export CONFIG_BASIC=y
+
+#Enable HAVE_GPG_KEY_BACKUP to test GPG key backup drive (we cannot inject config under QEMU (no internal flashing))
+#export CONFIG_HAVE_GPG_KEY_BACKUP=y
+
+#Enable DEBUG output
+#export CONFIG_DEBUG_OUTPUT=y
+#export CONFIG_ENABLE_FUNCTION_TRACING_OUTPUT=y
+#Enable TPM2 pcap output under /tmp
+#export CONFIG_TPM2_CAPTURE_PCAP=y
+
+#On-demand hardware support (modules.cpio)
+CONFIG_LINUX_USB=y
+CONFIG_LINUX_E1000=y
+#CONFIG_MOBILE_TETHERING=y
+#Runtime on-demand additional hardware support (modules.cpio)
+export CONFIG_LINUX_USB_COMPANION_CONTROLLER=y
+
+
+
+#Modules packed into tools.cpio
+ifeq "$(CONFIG_UROOT)" "y"
+CONFIG_BUSYBOX=n
+else
+#Modules packed into tools.cpio
+CONFIG_CRYPTSETUP2=y
+CONFIG_FLASHPROG=y
+CONFIG_FLASHTOOLS=y
+CONFIG_GPG2=y
+CONFIG_KEXEC=y
+CONFIG_UTIL_LINUX=y
+CONFIG_LVM2=y
+CONFIG_MBEDTLS=y
+CONFIG_PCIUTILS=y
+#Runtime tools to write to MSR
+#CONFIG_MSRTOOLS=y
+#Remote attestation support
+# TPM2 requirements
+CONFIG_TPM2_TSS=y
+CONFIG_OPENSSL=y
+#Remote Attestation common tools
+CONFIG_POPT=y
+CONFIG_QRENCODE=y
+CONFIG_TPMTOTP=y
+#HOTP based remote attestation for supported USB Security dongle
+#With/Without TPM support
+#CONFIG_HOTPKEY=y
+#Nitrokey Storage admin tool (deprecated)
+#CONFIG_NKSTORECLI=n
+#GUI Support
+#Console based Whiptail support(Console based, no FB):
+CONFIG_SLANG=y
+CONFIG_NEWT=y
+#FBWhiptail based (Graphical):
+#CONFIG_CAIRO=y
+#CONFIG_FBWHIPTAIL=y
+#Additional tools (tools.cpio):
+#SSH server (requires ethernet drivers, eg: CONFIG_LINUX_E1000E)
+CONFIG_DROPBEAR=y
+endif
+
+#Runtime configuration
+#Automatically boot if HOTP is valid
+export CONFIG_AUTO_BOOT_TIMEOUT=5
+#TPM2 requirements
+export CONFIG_TPM2_TOOLS=y
+export CONFIG_PRIMARY_KEY_TYPE=ecc
+#TPM1 requirements
+#export CONFIG_TPM=y
+export CONFIG_BOOTSCRIPT=/bin/gui-init
+#text-based original init:
+#export CONFIG_BOOTSCRIPT=/bin/generic-init
+export CONFIG_BOOT_REQ_HASH=n
+export CONFIG_BOOT_REQ_ROLLBACK=n
+export CONFIG_BOOT_RECOVERY_SERIAL="/dev/ttyS0"
+export CONFIG_BOOT_KERNEL_ADD="console=ttyS0 console=tty systemd.zram=0"
+export CONFIG_BOOT_KERNEL_REMOVE="quiet rhgb splash"
+export CONFIG_BOARD_NAME="qemu-coreboot-whiptail-tpm2"
+#export CONFIG_FLASH_OPTIONS="flashprog --progress --programmer internal"
+#export CONFIG_AUTO_BOOT_TIMEOUT=5
+
+BOARD_TARGETS := qemu


### PR DESCRIPTION
Those basically turn off TRACING, DEBUGGING and PCAP output as opposed to their standard non `-prod` counterpart:
```
#Enable DEBUG output
#export CONFIG_DEBUG_OUTPUT=y
#export CONFIG_ENABLE_FUNCTION_TRACING_OUTPUT=y
#Enable TPM2 pcap output under /tmp
#export CONFIG_TPM2_CAPTURE_PCAP=y
```

This is to facilitate non-platform specific features in virtualized environment.
Note that :
- coreboot config still enables high verbosity kernel output, but once Heads is running, the output is similar to production for tpm1/tpm2/hotp/non-hotp variants.
- OEM only ship HOTP variants
- HOTP variants still not play well with qemu tcg mode (non-kvm/non-nested virt environements like QubesOS: can't fix).

---
Will be used to develop #1822 
