### PR TITLE
add 3 Docker users/build helpers : local_dev, repro and latest, update README.md to simplify usage

### DIFF
--- a/docker_latest.sh
+++ b/docker_latest.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# Inform the user that the latest published Docker image is being used
+echo "Using the latest Docker image: tlaurion/heads-dev-env:latest"
+
+# Function to display usage information
+usage() {
+    echo "Usage: $0 [OPTIONS] -- [COMMAND]"
+    echo "Options:"
+    echo "  CPUS=N  Set the number of CPUs"
+    echo "  V=1     Enable verbose mode"
+    echo "Command:"
+    echo "  The command to run inside the Docker container, e.g., make BOARD=BOARD_NAME"
+}
+
+# Function to kill GPG toolstack related processes using USB devices
+kill_usb_processes() {
+    echo "Killing any GPG toolstack related processes on host currently using USB devices..."
+    sudo lsof /dev/bus/usb/00*/0* 2>/dev/null | awk 'NR>1 {print $2}' | xargs -r ps -p | grep -E 'scdaemon|pcscd' | awk '{print $1}' | xargs -r sudo kill -9
+    if [ $? -ne 0 ]; then
+        echo "Failed to kill GPG toolstack related processes using USB devices. Please run the following command manually:"
+        echo "sudo lsof /dev/bus/usb/00*/0* | awk 'NR>1 {print \$2}' | xargs -r ps -p | grep -E 'scdaemon|pcscd' | awk '{print \$1}' | xargs -r sudo kill -9"
+        exit 1
+    fi
+}
+
+# Handle Ctrl-C (SIGINT) to exit gracefully
+trap "echo 'Script interrupted. Exiting...'; exit 1" SIGINT
+
+# Check if --help or -h is provided
+for arg in "$@"; do
+    if [[ "$arg" == "--help" || "$arg" == "-h" ]]; then
+        usage
+        exit 0
+    fi
+done
+
+# Kill processes using USB devices
+kill_usb_processes
+
+# Inform the user about entering the Docker container
+echo "----"
+echo "Usage reminder: The minimal command is 'make BOARD=XYZ', where additional options, including 'V=1' or 'CPUS=N' are optional."
+echo "For more advanced QEMU testing options, refer to targets/qemu.md and boards/qemu-*/*.config."
+echo "----"
+echo "Entering the Docker container. Type 'exit' to return to the host shell."
+
+# Execute the docker run command with the provided parameters
+docker run --device=/dev/bus/usb:/dev/bus/usb -e DISPLAY=$DISPLAY --network host --rm -ti -v $(pwd):$(pwd) -w $(pwd) tlaurion/heads-dev-env:latest -- "$@"

--- a/docker_local_dev.sh
+++ b/docker_local_dev.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+# Check if Nix is installed
+if ! command -v nix &> /dev/null; then
+    echo "Nix is not installed or not in the PATH. Please install Nix before running this script."
+    echo "Refer to the README.md at the root of the repository for installation instructions."
+    exit 1
+fi
+
+# Check if Docker is installed
+if ! command -v docker &> /dev/null; then
+    echo "Docker is not installed or not in the PATH. Please install Docker before running this script."
+    echo "Refer to the README.md at the root of the repository for installation instructions."
+    exit 1
+fi
+
+# Inform the user about the Docker image being used
+echo "** This ./docker_local_dev.sh script is for developers usage only. **"
+echo ""
+echo "Using the last locally produced Docker image: linuxboot/heads:dev-env"
+echo "Warning: Using anything other than the published Docker image might lead to non-reproducible builds."
+echo ""
+echo "For using the latest published Docker image, refer to ./docker_latest.sh."
+echo "For producing reproducible builds as CircleCI, refer to ./docker_repro.sh."
+echo ""
+echo "---"
+
+# Function to display usage information
+usage() {
+    echo "Usage: $0 [OPTIONS] -- [COMMAND]"
+    echo "Options:"
+    echo "  CPUS=N  Set the number of CPUs"
+    echo "  V=1     Enable verbose mode"
+    echo "Command:"
+    echo "  The command to run inside the Docker container, e.g., make BOARD=BOARD_NAME"
+}
+
+# Function to kill GPG toolstack related processes using USB devices
+kill_usb_processes() {
+    echo "Killing any GPG toolstack related processes on host currently using USB devices..."
+    sudo lsof /dev/bus/usb/00*/0* 2>/dev/null | awk 'NR>1 {print $2}' | xargs -r ps -p | grep -E 'scdaemon|pcscd' | awk '{print $1}' | xargs -r sudo kill -9
+    if [ $? -ne 0 ]; then
+        echo "Failed to kill GPG toolstack related processes using USB devices. Please run the following command manually:"
+        echo "sudo lsof /dev/bus/usb/00*/0* | awk 'NR>1 {print \$2}' | xargs -r ps -p | grep -E 'scdaemon|pcscd' | awk '{print \$1}' | xargs -r sudo kill -9"
+        exit 1
+    fi
+}
+
+# Handle Ctrl-C (SIGINT) to exit gracefully
+trap "echo 'Script interrupted. Exiting...'; exit 1" SIGINT
+
+# Check if --help or -h is provided
+for arg in "$@"; do
+    if [[ "$arg" == "--help" || "$arg" == "-h" ]]; then
+        usage
+        exit 0
+    fi
+done
+
+# Check if the git repository is dirty and if flake.nix or flake.lock are part of the uncommitted changes
+if [ -n "$(git status --porcelain | grep -E 'flake\.nix|flake\.lock')" ]; then
+    echo "Warning: Uncommitted changes detected in flake.nix or flake.lock. The Docker image will be rebuilt."
+    echo "If this was not intended, please commit your changes and rerun the script."
+    echo "Building the Docker image from flake.nix..."
+    nix --print-build-logs --verbose develop --ignore-environment --command true
+    nix --print-build-logs --verbose build .#dockerImage && docker load < result
+else
+    echo "Git repository is clean. Using the previously built Docker image."
+    echo "---"
+    sleep 1
+fi
+
+# Kill processes using USB devices
+kill_usb_processes
+
+# Inform the user about entering the Docker container
+echo "----"
+echo "Usage reminder: The minimal command is 'make BOARD=XYZ', where additional options, including 'V=1' or 'CPUS=N' are optional."
+echo "For more advanced QEMU testing options, refer to targets/qemu.md and boards/qemu-*/*.config."
+echo "----"
+echo "Entering the Docker container. Type 'exit' to return to the host shell."
+
+# Execute the docker run command with the provided parameters
+docker run --device=/dev/bus/usb:/dev/bus/usb -e DISPLAY=$DISPLAY --network host --rm -ti -v $(pwd):$(pwd) -w $(pwd) linuxboot/heads:dev-env -- "$@"

--- a/docker_repro.sh
+++ b/docker_repro.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# Extract the Docker image version from the CircleCI config file
+DOCKER_IMAGE=$(grep -oP '^\s*-?\s*image:\s*\K(tlaurion/heads-dev-env:[^\s]+)' .circleci/config.yml | head -n 1)
+
+# Check if the Docker image was found
+if [ -z "$DOCKER_IMAGE" ]; then
+    echo "Error: Docker image not found in .circleci/config.yml"
+    exit 1
+fi
+
+# Inform the user about the versioned CircleCI Docker image being used
+echo "Using CircleCI Docker image: $DOCKER_IMAGE"
+
+# Function to display usage information
+usage() {
+    echo "Usage: $0 [OPTIONS] -- [COMMAND]"
+    echo "Options:"
+    echo "  CPUS=N  Set the number of CPUs"
+    echo "  V=1     Enable verbose mode"
+    echo "Command:"
+    echo "  The command to run inside the Docker container, e.g., make BOARD=BOARD_NAME"
+}
+
+# Function to kill GPG toolstack related processes using USB devices
+kill_usb_processes() {
+    echo "Killing any GPG toolstack related processes on host currently using USB devices..."
+    sudo lsof /dev/bus/usb/00*/0* 2>/dev/null | awk 'NR>1 {print $2}' | xargs -r ps -p | grep -E 'scdaemon|pcscd' | awk '{print $1}' | xargs -r sudo kill -9
+    if [ $? -ne 0 ]; then
+        echo "Failed to kill GPG toolstack related processes using USB devices. Please run the following command manually:"
+        echo "sudo lsof /dev/bus/usb/00*/0* | awk 'NR>1 {print \$2}' | xargs -r ps -p | grep -E 'scdaemon|pcscd' | awk '{print \$1}' | xargs -r sudo kill -9"
+        exit 1
+    fi
+}
+
+# Handle Ctrl-C (SIGINT) to exit gracefully
+trap "echo 'Script interrupted. Exiting...'; exit 1" SIGINT
+
+# Check if --help or -h is provided
+for arg in "$@"; do
+    if [[ "$arg" == "--help" || "$arg" == "-h" ]]; then
+        usage
+        exit 0
+    fi
+done
+
+# Kill processes using USB devices
+kill_usb_processes
+
+# Inform the user about entering the Docker container
+echo "----"
+echo "Usage reminder: The minimal command is 'make BOARD=XYZ', where additional options, including 'V=1' or 'CPUS=N' are optional."
+echo "For more advanced QEMU testing options, refer to targets/qemu.md and boards/qemu-*/*.config."
+echo "----"
+echo "Entering the Docker container. Type 'exit' to return to the host shell."
+
+# Execute the docker run command with the provided parameters
+docker run --device=/dev/bus/usb:/dev/bus/usb -e DISPLAY=$DISPLAY --network host --rm -ti -v $(pwd):$(pwd) -w $(pwd) $DOCKER_IMAGE -- "$@"


### PR DESCRIPTION
This pull request includes significant updates to the `README.md` file and the addition of three new helper scripts for creating/consuming Docker images. The changes aim to streamline the development/usage workflow and enhance reproducibility.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R58-R61): Updated instructions for building the Docker image and provided details about three new helper scripts: `docker_local_dev.sh`, `docker_latest.sh`, and `docker_repro.sh`. Clarified the reproducibility of builds and provided examples for using these scripts. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R58-R61) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L78-R87) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L95-R114)

New helper scripts:

* [`docker_local_dev.sh`](diffhunk://#diff-fc7abd574dec7a1330541376511d8bddd07d46e30d4242f437db2bfdb062a60cR1-R84): Added a script to build and use a local;y created Docker image from nix flakes.nix and flakes.lock for local development, including checks for Nix and Docker installations, and a warning about non-reproducible builds and docker usage once jumped in it
* [`docker_latest.sh`](diffhunk://#diff-d7f6f52a5aca03eec4bb0d5bd60bf208ee67f1e951257dbfae0c663c517d76c5R1-R49): Added a script to use the latest published Docker image for development, with options for setting the number of CPUs and enabling verbose mode
* [`docker_repro.sh`](diffhunk://#diff-4a31bef3a62e9dd896a7db2b379486751b7311cae240253f48bcdac0f78c1fd2R1-R58): Added a script to use the versioned Docker image specified in the CircleCI configuration for reproducible builds, with options for setting the number of CPUs and enabling verbose mode.


---
Fixes longterm issue of being able to use USB Security dongles under QubesOS with Qemu not being able to obtain usb devices exclusivity as opposed to kvm. The scripts kill gpg toolstack consumers of usb devices on host.

Finally fixes #1490 