### PR TITLE
docker_* helpers: pass usb host controllers to docker only if usb devices are connected, unify, bugfixes

### DIFF
--- a/docker_latest.sh
+++ b/docker_latest.sh
@@ -2,26 +2,27 @@
 
 # Inform the user that the latest published Docker image is being used
 echo "Using the latest Docker image: tlaurion/heads-dev-env:latest"
+DOCKER_IMAGE="tlaurion/heads-dev-env:latest"
 
 # Function to display usage information
 usage() {
-    echo "Usage: $0 [OPTIONS] -- [COMMAND]"
-    echo "Options:"
-    echo "  CPUS=N  Set the number of CPUs"
-    echo "  V=1     Enable verbose mode"
-    echo "Command:"
-    echo "  The command to run inside the Docker container, e.g., make BOARD=BOARD_NAME"
+	echo "Usage: $0 [OPTIONS] -- [COMMAND]"
+	echo "Options:"
+	echo "  CPUS=N  Set the number of CPUs"
+	echo "  V=1     Enable verbose mode"
+	echo "Command:"
+	echo "  The command to run inside the Docker container, e.g., make BOARD=BOARD_NAME"
 }
 
 # Function to kill GPG toolstack related processes using USB devices
 kill_usb_processes() {
-    echo "Killing any GPG toolstack related processes on host currently using USB devices..."
-    sudo lsof /dev/bus/usb/00*/0* 2>/dev/null | awk 'NR>1 {print $2}' | xargs -r ps -p | grep -E 'scdaemon|pcscd' | awk '{print $1}' | xargs -r sudo kill -9
-    if [ $? -ne 0 ]; then
-        echo "Failed to kill GPG toolstack related processes using USB devices. Please run the following command manually:"
-        echo "sudo lsof /dev/bus/usb/00*/0* | awk 'NR>1 {print \$2}' | xargs -r ps -p | grep -E 'scdaemon|pcscd' | awk '{print \$1}' | xargs -r sudo kill -9"
-        exit 1
-    fi
+	# check if scdaemon or pcscd processes are using USB devices
+	if [ -d /dev/bus/usb ]; then
+		if sudo lsof /dev/bus/usb/00*/0* 2>/dev/null | awk 'NR>1 {print $2}' | xargs -r ps -p | grep -E 'scdaemon|pcscd' >/dev/null; then
+			echo "Killing GPG toolstack related processes using USB devices..."
+			sudo lsof /dev/bus/usb/00*/0* 2>/dev/null | awk 'NR>1 {print $2}' | xargs -r ps -p | grep -E 'scdaemon|pcscd' | awk '{print $1}' | xargs -r sudo kill -9
+		fi
+	fi
 }
 
 # Handle Ctrl-C (SIGINT) to exit gracefully
@@ -29,10 +30,10 @@ trap "echo 'Script interrupted. Exiting...'; exit 1" SIGINT
 
 # Check if --help or -h is provided
 for arg in "$@"; do
-    if [[ "$arg" == "--help" || "$arg" == "-h" ]]; then
-        usage
-        exit 0
-    fi
+	if [[ "$arg" == "--help" || "$arg" == "-h" ]]; then
+		usage
+		exit 0
+	fi
 done
 
 # Kill processes using USB devices
@@ -42,8 +43,16 @@ kill_usb_processes
 echo "----"
 echo "Usage reminder: The minimal command is 'make BOARD=XYZ', where additional options, including 'V=1' or 'CPUS=N' are optional."
 echo "For more advanced QEMU testing options, refer to targets/qemu.md and boards/qemu-*/*.config."
+echo
+echo "Type exit within docker image to get back to host if launched interactively!"
 echo "----"
-echo "Entering the Docker container. Type 'exit' to return to the host shell."
+echo
 
 # Execute the docker run command with the provided parameters
-docker run --device=/dev/bus/usb:/dev/bus/usb -e DISPLAY=$DISPLAY --network host --rm -ti -v $(pwd):$(pwd) -w $(pwd) tlaurion/heads-dev-env:latest -- "$@"
+if [ -d "/dev/bus/usb" ]; then
+	echo "--->Launching container with access to host's USB buses (some USB devices were connected to host)..."
+	docker run --device=/dev/bus/usb:/dev/bus/usb -e DISPLAY=$DISPLAY --network host --rm -ti -v $(pwd):$(pwd) -w $(pwd) $DOCKER_IMAGE -- "$@"
+else
+	echo "--->Launching container without access to host's USB buses (no USB devices was connected to host)..."
+	docker run -e DISPLAY=$DISPLAY --network host --rm -ti -v $(pwd):$(pwd) -w $(pwd) $DOCKER_IMAGE -- "$@"
+fi

--- a/docker_local_dev.sh
+++ b/docker_local_dev.sh
@@ -1,49 +1,51 @@
 #!/bin/bash
 
+#locally build docker name is linuxboot/heads:dev-env
+DOCKER_IMAGE="linuxboot/heads:dev-env"
+
 # Check if Nix is installed
-if ! command -v nix &> /dev/null; then
-    echo "Nix is not installed or not in the PATH. Please install Nix before running this script."
-    echo "Refer to the README.md at the root of the repository for installation instructions."
-    exit 1
+if ! command -v nix &>/dev/null; then
+	echo "Nix is not installed or not in the PATH. Please install Nix before running this script."
+	echo "Refer to the README.md at the root of the repository for installation instructions."
+	exit 1
 fi
 
 # Check if Docker is installed
-if ! command -v docker &> /dev/null; then
-    echo "Docker is not installed or not in the PATH. Please install Docker before running this script."
-    echo "Refer to the README.md at the root of the repository for installation instructions."
-    exit 1
+if ! command -v docker &>/dev/null; then
+	echo "Docker is not installed or not in the PATH. Please install Docker before running this script."
+	echo "Refer to the README.md at the root of the repository for installation instructions."
+	exit 1
 fi
 
 # Inform the user about the Docker image being used
-echo "** This ./docker_local_dev.sh script is for developers usage only. **"
+echo "!!! This ./docker_local_dev.sh script is for developers usage only. !!!"
 echo ""
-echo "Using the last locally produced Docker image: linuxboot/heads:dev-env"
-echo "Warning: Using anything other than the published Docker image might lead to non-reproducible builds."
+echo "Using the last locally built Docker image when flake.nix/flake.lock was modified and repo was dirty: linuxboot/heads:dev-env"
+echo "!!! Warning: Using anything other than the published Docker image might lead to non-reproducible builds. !!!"
 echo ""
 echo "For using the latest published Docker image, refer to ./docker_latest.sh."
 echo "For producing reproducible builds as CircleCI, refer to ./docker_repro.sh."
 echo ""
-echo "---"
 
 # Function to display usage information
 usage() {
-    echo "Usage: $0 [OPTIONS] -- [COMMAND]"
-    echo "Options:"
-    echo "  CPUS=N  Set the number of CPUs"
-    echo "  V=1     Enable verbose mode"
-    echo "Command:"
-    echo "  The command to run inside the Docker container, e.g., make BOARD=BOARD_NAME"
+	echo "Usage: $0 [OPTIONS] -- [COMMAND]"
+	echo "Options:"
+	echo "  CPUS=N  Set the number of CPUs"
+	echo "  V=1     Enable verbose mode"
+	echo "Command:"
+	echo "  The command to run inside the Docker container, e.g., make BOARD=BOARD_NAME"
 }
 
 # Function to kill GPG toolstack related processes using USB devices
 kill_usb_processes() {
-    echo "Killing any GPG toolstack related processes on host currently using USB devices..."
-    sudo lsof /dev/bus/usb/00*/0* 2>/dev/null | awk 'NR>1 {print $2}' | xargs -r ps -p | grep -E 'scdaemon|pcscd' | awk '{print $1}' | xargs -r sudo kill -9
-    if [ $? -ne 0 ]; then
-        echo "Failed to kill GPG toolstack related processes using USB devices. Please run the following command manually:"
-        echo "sudo lsof /dev/bus/usb/00*/0* | awk 'NR>1 {print \$2}' | xargs -r ps -p | grep -E 'scdaemon|pcscd' | awk '{print \$1}' | xargs -r sudo kill -9"
-        exit 1
-    fi
+	# check if scdaemon or pcscd processes are using USB devices
+	if [ -d /dev/bus/usb ]; then
+		if sudo lsof /dev/bus/usb/00*/0* 2>/dev/null | awk 'NR>1 {print $2}' | xargs -r ps -p | grep -E 'scdaemon|pcscd' >/dev/null; then
+			echo "Killing GPG toolstack related processes using USB devices..."
+			sudo lsof /dev/bus/usb/00*/0* 2>/dev/null | awk 'NR>1 {print $2}' | xargs -r ps -p | grep -E 'scdaemon|pcscd' | awk '{print $1}' | xargs -r sudo kill -9
+		fi
+	fi
 }
 
 # Handle Ctrl-C (SIGINT) to exit gracefully
@@ -51,23 +53,22 @@ trap "echo 'Script interrupted. Exiting...'; exit 1" SIGINT
 
 # Check if --help or -h is provided
 for arg in "$@"; do
-    if [[ "$arg" == "--help" || "$arg" == "-h" ]]; then
-        usage
-        exit 0
-    fi
+	if [[ "$arg" == "--help" || "$arg" == "-h" ]]; then
+		usage
+		exit 0
+	fi
 done
 
 # Check if the git repository is dirty and if flake.nix or flake.lock are part of the uncommitted changes
 if [ -n "$(git status --porcelain | grep -E 'flake\.nix|flake\.lock')" ]; then
-    echo "Warning: Uncommitted changes detected in flake.nix or flake.lock. The Docker image will be rebuilt."
-    echo "If this was not intended, please commit your changes and rerun the script."
-    echo "Building the Docker image from flake.nix..."
-    nix --print-build-logs --verbose develop --ignore-environment --command true
-    nix --print-build-logs --verbose build .#dockerImage && docker load < result
+	echo "**Warning: Uncommitted changes detected in flake.nix or flake.lock. The Docker image will be rebuilt!**"
+	echo "If this was not intended, please CTRL-C now, commit your changes and rerun the script."
+	echo "Building the Docker image from flake.nix..."
+	nix --print-build-logs --verbose develop --ignore-environment --command true
+	nix --print-build-logs --verbose build .#dockerImage && docker load <result
 else
-    echo "Git repository is clean. Using the previously built Docker image."
-    echo "---"
-    sleep 1
+	echo "Git repository is clean. Using the previously built Docker image when repository was unclean and flake.nix/flake.lock changes were uncommited."
+	sleep 1
 fi
 
 # Kill processes using USB devices
@@ -77,8 +78,16 @@ kill_usb_processes
 echo "----"
 echo "Usage reminder: The minimal command is 'make BOARD=XYZ', where additional options, including 'V=1' or 'CPUS=N' are optional."
 echo "For more advanced QEMU testing options, refer to targets/qemu.md and boards/qemu-*/*.config."
+echo
+echo "Type exit within docker image to get back to host if launched interactively!"
 echo "----"
-echo "Entering the Docker container. Type 'exit' to return to the host shell."
+echo
 
 # Execute the docker run command with the provided parameters
-docker run --device=/dev/bus/usb:/dev/bus/usb -e DISPLAY=$DISPLAY --network host --rm -ti -v $(pwd):$(pwd) -w $(pwd) linuxboot/heads:dev-env -- "$@"
+if [ -d "/dev/bus/usb" ]; then
+	echo "--->Launching container with access to host's USB buses (some USB devices were connected to host)..."
+	docker run --device=/dev/bus/usb:/dev/bus/usb -e DISPLAY=$DISPLAY --network host --rm -ti -v $(pwd):$(pwd) -w $(pwd) $DOCKER_IMAGE -- "$@"
+else
+	echo "--->Launching container without access to host's USB buses (no USB devices was connected to host)..."
+	docker run -e DISPLAY=$DISPLAY --network host --rm -ti -v $(pwd):$(pwd) -w $(pwd) $DOCKER_IMAGE -- "$@"
+fi


### PR DESCRIPTION
This pull request includes changes to improve the handling of Docker images and the management of USB devices in the `docker_latest.sh`, `docker_local_dev.sh`, and `docker_repro.sh` scripts. The most important changes include setting Docker image variables, enhancing the `kill_usb_processes` function, and modifying the Docker run commands to handle USB device access more intelligently.

### Docker Image Handling:

* Added a `DOCKER_IMAGE` variable to store the Docker image name in `docker_latest.sh` and `docker_local_dev.sh`. This improves consistency and makes it easier to update the image name in the future. [[1]](diffhunk://#diff-d7f6f52a5aca03eec4bb0d5bd60bf208ee67f1e951257dbfae0c663c517d76c5R5) [[2]](diffhunk://#diff-fc7abd574dec7a1330541376511d8bddd07d46e30d4242f437db2bfdb062a60cR3-R5)

### USB Device Management:

* Enhanced the `kill_usb_processes` function to check if `scdaemon` or `pcscd` processes are using USB devices before attempting to kill them. This prevents unnecessary error messages and ensures only relevant processes are targeted. [[1]](diffhunk://#diff-d7f6f52a5aca03eec4bb0d5bd60bf208ee67f1e951257dbfae0c663c517d76c5L18-R24) [[2]](diffhunk://#diff-fc7abd574dec7a1330541376511d8bddd07d46e30d4242f437db2bfdb062a60cL40-R47) [[3]](diffhunk://#diff-4a31bef3a62e9dd896a7db2b379486751b7311cae240253f48bcdac0f78c1fd2L27-R32)

### Docker Run Command:

* Modified the Docker run commands to conditionally include USB device access based on the presence of USB devices on the host. This ensures that the Docker container is launched with appropriate permissions and resources. [[1]](diffhunk://#diff-d7f6f52a5aca03eec4bb0d5bd60bf208ee67f1e951257dbfae0c663c517d76c5R46-R58) [[2]](diffhunk://#diff-fc7abd574dec7a1330541376511d8bddd07d46e30d4242f437db2bfdb062a60cR81-R93) [[3]](diffhunk://#diff-4a31bef3a62e9dd896a7db2b379486751b7311cae240253f48bcdac0f78c1fd2R54-R66)