### PR TITLE
modules/lvm2: define /run relative paths (not sure why circleci remote docker default run dir != local run dir)

### DIFF
--- a/modules/lvm2
+++ b/modules/lvm2
@@ -16,6 +16,9 @@ lvm2_configure := \
 	--host $(MUSL_ARCH)-elf-linux \
 	--prefix "" \
 	--libexecdir "/bin" \
+	--with-default-pid-dir=/run \
+	--with-default-dm-run-dir=/run \
+	--with-default-run-dir=/run/lvm \
 	--with-optimisation=-Os \
 	--enable-devmapper \
 	--disable-selinux \


### PR DESCRIPTION
This fixes #1857

Was artifact of lvm2 version bump that happened under #1541.
TODO: figure out what still bled here to cause discrepancy, will attach diffoscope logs to #1857  