### PR TITLE
initrd/bin/unpack_initramfs.sh: add xz unpacking support.

### DIFF
--- a/initrd/bin/unpack_initramfs.sh
+++ b/initrd/bin/unpack_initramfs.sh
@@ -90,6 +90,10 @@ unpack_first_segment() {
 			# walking all the compressed blocks.
 			gunzip | unpack_cpio
 			;;
+		fd37*) # xz
+			DEBUG "archive segment $magic: xz"
+			unxz | unpack_cpio
+			;;
 		28b5*) # zstd
 			DEBUG "archive segment $magic: zstd"
 			# Like gunzip, this will not stop when reaching the end of the
@@ -99,6 +103,26 @@ unpack_first_segment() {
 			;;
 		*) # unknown
 			die "Can't decompress initramfs archive, unknown type: $magic"
+			# The following are magic values for other compression formats
+			#  but not added because not tested.
+			# TODO: open an issue for unsupported magic number reported on die.
+			# 
+			#425a*) # bzip2
+			#	DEBUG "archive segment $magic: bzip2"
+			#	bunzip2 | unpack_cpio
+			#;;
+			#5d00*) # lzma
+			#	DEBUG "archive segment $magic: lzma"
+			#	unlzma | unpack_cpio
+			#;;
+			#894c*) # lzo
+			#	DEBUG "archive segment $magic: lzo"
+			#	lzop -d | unpack_cpio
+			#;;
+			#0221*) # lz4
+			#	DEBUG "archive segment $magic: lz4"
+			#	lz4 -d | unpack_cpio
+			#	;;
 			;;
 		esac
 	) <"$unpack_archive" >"$rest_archive"

--- a/initrd/bin/unpack_initramfs.sh
+++ b/initrd/bin/unpack_initramfs.sh
@@ -31,78 +31,81 @@ CPIO_ARGS=("$@")
 
 # Consume zero bytes, the first nonzero byte read (if any) is repeated on stdout
 consume_zeros() {
-    TRACE_FUNC
-    next_byte='00'
-    while [ "$next_byte" = "00" ]; do
-        # if we reach EOF, next_byte becomes empty (dd does not fail)
-        next_byte="$(dd bs=1 count=1 status=none | xxd -p | tr -d ' ')"
-    done
-    # if we finished due to nonzero byte (not EOF), then carry that byte
-    if [ -n "$next_byte" ]; then
-        echo -n "$next_byte" | xxd -p -r
-    fi
+	TRACE_FUNC
+	next_byte='00'
+	while [ "$next_byte" = "00" ]; do
+		# if we reach EOF, next_byte becomes empty (dd does not fail)
+		next_byte="$(dd bs=1 count=1 status=none | xxd -p | tr -d ' ')"
+	done
+	# if we finished due to nonzero byte (not EOF), then carry that byte
+	if [ -n "$next_byte" ]; then
+		echo -n "$next_byte" | xxd -p -r
+	fi
 }
 
 unpack_cpio() {
-    TRACE_FUNC
-    (cd "$dest_dir"; cpio -i "${CPIO_ARGS[@]}" 2>/dev/null)
+	TRACE_FUNC
+	(
+		cd "$dest_dir"
+		cpio -i "${CPIO_ARGS[@]}" 2>/dev/null
+	)
 }
 
 # unpack the first segment of an archive, then write the rest to another file
 unpack_first_segment() {
-    TRACE_FUNC
-    unpack_archive="$1"
-    dest_dir="$2"
-    rest_archive="$3"
+	TRACE_FUNC
+	unpack_archive="$1"
+	dest_dir="$2"
+	rest_archive="$3"
 
-    mkdir -p "$dest_dir"
+	mkdir -p "$dest_dir"
 
-    # peek the beginning of the file to determine what type of content is next
-    magic="$(dd if="$unpack_archive" bs=6 count=1 status=none | xxd -p)"
+	# peek the beginning of the file to determine what type of content is next
+	magic="$(dd if="$unpack_archive" bs=6 count=1 status=none | xxd -p)"
 
-    # read this segment of the archive, then write the rest to the next file
-    (
-        # Magic values correspond to Linux init/initramfs.c (zero, cpio) and
-        # lib/decompress.c (gzip)
-        case "$magic" in
-            00*)
-                DEBUG "archive segment $magic: uncompressed cpio"
-                # Skip zero bytes and copy the first nonzero byte
-                consume_zeros
-                # Copy the remaining data
-                cat
-                ;;
-            303730373031*|303730373032*)    # plain cpio
-                DEBUG "archive segment $magic: plain cpio"
-                # Unpack the plain cpio, this stops reading after the trailer
-                unpack_cpio
-                # Copy the remaining data
-                cat
-                ;;
-            1f8b*|1f9e*)    # gzip
-                DEBUG "archive segment $magic: gzip"
-                # gunzip won't stop when reaching the end of the gzipped member,
-                # so we can't read another segment after this.  We can't
-                # reasonably determine the member length either, this requires
-                # walking all the compressed blocks.
-                gunzip | unpack_cpio
-                ;;
-            28b5*)  # zstd
-                DEBUG "archive segment $magic: zstd"
-                # Like gunzip, this will not stop when reaching the end of the
-                # frame, and determining the frame length requires walking all
-                # of its blocks.
-                (zstd-decompress -d || true) | unpack_cpio
-                ;;
-            *)  # unknown
-                die "Can't decompress initramfs archive, unknown type: $magic"
-                ;;
-        esac
-    ) <"$unpack_archive" >"$rest_archive"
+	# read this segment of the archive, then write the rest to the next file
+	(
+		# Magic values correspond to Linux init/initramfs.c (zero, cpio) and
+		# lib/decompress.c (gzip)
+		case "$magic" in
+		00*)
+			DEBUG "archive segment $magic: uncompressed cpio"
+			# Skip zero bytes and copy the first nonzero byte
+			consume_zeros
+			# Copy the remaining data
+			cat
+			;;
+		303730373031* | 303730373032*) # plain cpio
+			DEBUG "archive segment $magic: plain cpio"
+			# Unpack the plain cpio, this stops reading after the trailer
+			unpack_cpio
+			# Copy the remaining data
+			cat
+			;;
+		1f8b* | 1f9e*) # gzip
+			DEBUG "archive segment $magic: gzip"
+			# gunzip won't stop when reaching the end of the gzipped member,
+			# so we can't read another segment after this.  We can't
+			# reasonably determine the member length either, this requires
+			# walking all the compressed blocks.
+			gunzip | unpack_cpio
+			;;
+		28b5*) # zstd
+			DEBUG "archive segment $magic: zstd"
+			# Like gunzip, this will not stop when reaching the end of the
+			# frame, and determining the frame length requires walking all
+			# of its blocks.
+			(zstd-decompress -d || true) | unpack_cpio
+			;;
+		*) # unknown
+			die "Can't decompress initramfs archive, unknown type: $magic"
+			;;
+		esac
+	) <"$unpack_archive" >"$rest_archive"
 
-    orig_size="$(stat -c %s "$unpack_archive")"
-    rest_size="$(stat -c %s "$rest_archive")"
-    DEBUG "archive segment $magic: $((orig_size - rest_size)) bytes"
+	orig_size="$(stat -c %s "$unpack_archive")"
+	rest_size="$(stat -c %s "$rest_archive")"
+	DEBUG "archive segment $magic: $((orig_size - rest_size)) bytes"
 }
 
 DEBUG "Unpacking $INITRAMFS_ARCHIVE to $DEST_DIR"
@@ -112,7 +115,7 @@ rest_archive="/tmp/unpack_initramfs_rest"
 
 # Break when there is no remaining data
 while [ -s "$next_archive" ]; do
-    unpack_first_segment "$next_archive" "$DEST_DIR" "$rest_archive"
-    next_archive="/tmp/unpack_initramfs_next"
-    mv "$rest_archive" "$next_archive"
+	unpack_first_segment "$next_archive" "$DEST_DIR" "$rest_archive"
+	next_archive="/tmp/unpack_initramfs_next"
+	mv "$rest_archive" "$next_archive"
 done


### PR DESCRIPTION
Closes https://github.com/linuxboot/heads/issues/1644 : was preventing to setup TPM DUK key because initrd couldn't be unpacked and repacked on the fly to be passed at kexec call to contain unsealed DUK key for final OS to pick up and use to unlock LUKS on boot.

- reformat with tabs and unify

[95c6eb5](https://github.com/linuxboot/heads/pull/1860/commits/95c6eb5c498bebc028cd92d62c83e33c2be3ed2e):
- adds xz unpacking that was missing and needed for debian derivatives.
- other format added in comments so easy to test when testing candidates will be reported in the wild

Ubuntu 24.10 switched from lz4 to zstd which was already supported, so does not add lz4 but still closes #1644 :)

---

**xz unpacking**

Before:
![signal-2024-11-22-160535](https://github.com/user-attachments/assets/8fe27c57-06fc-4e83-924e-9370874c192f)

After this PR:
![signal-2024-11-22-173850](https://github.com/user-attachments/assets/2d519115-7887-4a71-a387-ffed742e5e6e)


Which permitted to extract exfat.ko size, which was needed for #1810:
![signal-2024-11-22-174226](https://github.com/user-attachments/assets/8d7558a4-b6d9-4942-ac85-d8b1387f8994)


