### PR TITLE
bugfix: oem-factory-reset: debug mode; hide passphrase output on screen/debug log on gpg --detach-sign of /boot hash digest

### DIFF
--- a/initrd/bin/oem-factory-reset
+++ b/initrd/bin/oem-factory-reset
@@ -680,7 +680,7 @@ generate_checksums() {
     fi
 
     DEBUG "Detach-signing boot files under kexec.sig: ${param_files}"
-    if sha256sum $param_files 2>/dev/null | DO_WITH_DEBUG gpg \
+    if sha256sum $param_files 2>/dev/null | DO_WITH_DEBUG --mask-position 4 gpg \
         --pinentry-mode loopback \
         --passphrase "${USER_PIN}" \
         --digest-algo SHA256 \


### PR DESCRIPTION
Before:
`[  155.845101] DEBUG: gpg --pinentry-mode loopback --passphrase Please Change Me --digest-algo SHA256 --detach-sign -a`

After:
`[  131.272954] DEBUG: gpg --pinentry-mode loopback --passphrase <hidden> --digest-algo SHA256 --detach-sign -a`