### PR TITLE
modules/flashprog: bump to latest commit, including support for meteor lake

### DIFF
--- a/modules/flashprog
+++ b/modules/flashprog
@@ -2,11 +2,11 @@ modules-$(CONFIG_FLASHPROG) += flashprog
 
 flashprog_depends := pciutils $(musl_dep)
 
-flashprog_version := 9dc6d843b0678001c9baf0e8602ecb25b16329d2
+flashprog_version := eb2c04185f8f471c768b742d66e4c552effdd9cb
 flashprog_dir := flashprog-$(flashprog_version)
 flashprog_tar := $(flashprog_dir).tar.gz
 flashprog_url := https://github.com/SourceArcade/flashprog/archive/$(flashprog_version).tar.gz
-flashprog_hash := fa4ddf3b60314994a37e4599122ae4c7f42135c13c782e580bc580d715cfa2fc
+flashprog_hash := 0d4186be9f2088d624a9a708c352d0dfafa2264e1436b11ec3cc1a350fd45a77
 
 # Default options for flashprog
 flashprog_cfg := \


### PR DESCRIPTION
- We use https://github.com/SourceArcade/flashprog/commit/eb2c04185f8f471c768b742d66e4c552effdd9cb (2024-11-21 1.3+ bugfixes) 
-  meteor lake support is https://github.com/SourceArcade/flashprog/commit/5e0d9b04a07f5646038020e1a45dd04c0b14e8f3 is from 1.3 (3 weeks ago)


To be tested under #1846 and reported functional so I can press merge button. Will test on nv41 and x230 on my side, seeing changes, we should not have regressions

CC @i-c-o-n @mkopec 

----

Test regression (once Ci builds everything supported today) on my side for 

- [x] x230 (sandy/ivy representative)
- [x] nv41 (alder lake represenative)

Other:
- [x]  n504tu reported working for internal flashing from @mkopec for #1846
- [x] merge 