### PR TITLE
modules/coreboot: set Dasharo coreboot fork rev to the main dasharo branch

### DIFF
--- a/modules/coreboot
+++ b/modules/coreboot
@@ -94,7 +94,7 @@ $(eval $(call coreboot_module,purism,24.02.01))
 # MSI and NovaCustom NV4xPZ, NS5xPU, V560TU boards are based on Dasharo
 # coreboot fork, based on upstream coreboot version 24.02
 coreboot-dasharo_repo := https://github.com/dasharo/coreboot
-coreboot-dasharo_commit_hash := 94e5f5d5b808cf8d8fd5c70d4ef6a08a054f8986
+coreboot-dasharo_commit_hash := 048ca832325d716fcab596822b10f5d493fc2312
 $(eval $(call coreboot_module,dasharo,24.02.01))
 #coreboot-dasharo_patch_version := unreleased
 


### PR DESCRIPTION
Here are the changes (mostly irrelevant to Heads) that were merged after https://github.com/linuxboot/heads/pull/1846:
- Support for capsule updates (inactive for Heads build)
- Added NovaCustom MTL dGPU variants
- EC firmware update in coreboot (inactive for Heads build)

Changes that affect V560TU:
- Added support for reading power adapter wattage via ACPI
- Fixes for USB not working
- Add AC/DC loadline programming, for better stability
- Fixes for ME disable
- Fixes for Ethernet detection

I've tested booting into Qubes, ethernet detection, and USB type-A.


tlaurion edit: took https://github.com/linuxboot/heads/pull/1889#issuecomment-2598297536 content 