### PR TITLE
Revert "modules/coreboot: set Dasharo coreboot fork rev to the main dasharo branch"

### DIFF
--- a/modules/coreboot
+++ b/modules/coreboot
@@ -94,7 +94,7 @@ $(eval $(call coreboot_module,purism,24.02.01))
 # MSI and NovaCustom NV4xPZ, NS5xPU, V560TU boards are based on Dasharo
 # coreboot fork, based on upstream coreboot version 24.02
 coreboot-dasharo_repo := https://github.com/dasharo/coreboot
-coreboot-dasharo_commit_hash := 048ca832325d716fcab596822b10f5d493fc2312
+coreboot-dasharo_commit_hash := 94e5f5d5b808cf8d8fd5c70d4ef6a08a054f8986
 $(eval $(call coreboot_module,dasharo,24.02.01))
 #coreboot-dasharo_patch_version := unreleased
 


### PR DESCRIPTION
Reverts linuxboot/heads#1889

Unfortunately, on 3 attempts I was not able to either boot QubesOS 4.2.3 first stage, or install templates on second stage.
Also my nv41 "instant rebooted today".

Strategy will be to create another branch of #1875 with the changes in, and revert this as well under #1875.