### PR TITLE
nitropad/novacustom board configs: point to Dasharo docs for disassembly and recovery instructions

### DIFF
--- a/boards/UNTESTED_nitropad-ns50/UNTESTED_nitropad-ns50.config
+++ b/boards/UNTESTED_nitropad-ns50/UNTESTED_nitropad-ns50.config
@@ -1,5 +1,8 @@
 # Nitrokey Nitropad NS51 board configuration
 # Note: for reference, other GOP enabled FB board is librem_11
+#
+# Docs:
+#  Dissassembly and Recovery: https://docs.dasharo.com/unified/novacustom/recovery/#ns5x7x-12th-gen
 
 export CONFIG_COREBOOT=y
 export CONFIG_COREBOOT_VERSION=dasharo

--- a/boards/novacustom-v560tu/novacustom-v560tu.config
+++ b/boards/novacustom-v560tu/novacustom-v560tu.config
@@ -2,8 +2,16 @@
 # Note the FLASH_OPTIONS: '--ifd -i bios -i me -i fd'
 #  This excludes gbe from internal flashing, otherwise mac address would revert to '88:88:88:88:87:88' see https://github.com/linuxboot/heads/pull/1871#discussion_r1870134788
 #   Same options should be used when externally flashing the first time, otherwise Intel GBE region (Ethernet config blob) will be overwitten and MAC reverted to '88:88:88:88:87:88'
-
-# Meteor Lake (Intel Gen 14) is not supposed to support s3 but coincidently does. In case s3 is broken, user must configure settings to not suspend or otherwise enable ME/CSME for s0ix to work (unsupported by QubesOS when writing those lines) or use Hibernate (Not supported by QubesOS either)
+#
+# Docs:
+#  Dissassembly and Recovery: https://docs.dasharo.com/unified/novacustom/recovery/#14th-gen
+#
+# WARNING: The first boot after updating firmware may take a longer time than usual, due to DDR5 memory being re-trained. 
+#  Generally, first boot time increases according to the amount of installed RAM in the system. A system with 64 GB of RAM may take over 2 minutes to boot.
+#  After first boot, memory training settings are cached, and subsequent boot times should be much lower.
+#
+# DISCLAIMER: Meteor Lake (Intel Gen 14) is not supposed to support s3 but coincidently does. In case s3 is broken, user must configure settings to not suspend or otherwise enable 
+#  ME/CSME for s0ix to work (unsupported by QubesOS when writing those lines) or use Hibernate (Not supported by QubesOS either)
 
 export CONFIG_COREBOOT=y
 export CONFIG_COREBOOT_VERSION=dasharo

--- a/boards/novacustom_nv4x_adl/novacustom_nv4x_adl.config
+++ b/boards/novacustom_nv4x_adl/novacustom_nv4x_adl.config
@@ -1,5 +1,8 @@
 # NovaCustom NV4x 12th Gen (nv40pz: Alder Lake) board configuration
 # Note: for reference, other GOP enabled FB board is librem_11
+#
+# Docs:
+#  Dissassembly and Recovery: https://docs.dasharo.com/unified/novacustom/recovery/#12th-gen 
 
 export CONFIG_COREBOOT=y
 export CONFIG_COREBOOT_VERSION=dasharo


### PR DESCRIPTION
Closes #1893 while specifying that v560tu DDR5 memory training might take up to 2 minutes for 64GB+ HCL.

Points boards to related disassembly and recovery instructions to not have to duplicate them,

@macpijan please approve.