### PR TITLE
blobs/xx30/optiplex_7010_9010.sh: use web.arhive.org to download zip containing ivy/sandy file now missing upstream.

### DIFF
--- a/blobs/xx30/optiplex_7010_9010.sh
+++ b/blobs/xx30/optiplex_7010_9010.sh
@@ -32,9 +32,11 @@ if [[ ! -f "${output_dir}/IVB_BIOSAC_PRODUCTION.bin" ]] || [[ ! -f "${output_dir
     mv IVB_BIOSAC_PRODUCTION.bin "${output_dir}/"
 
     #Download sinit
-    wget https://cdrdv2.intel.com/v1/dl/getContent/630744 -O sinit.zip
+    # Original URL got rid of needed file, keeping original URL. Let's use archive.org
+    #wget https://cdrdv2.intel.com/v1/dl/getContent/630744 -O sinit.zip
+    wget http://web.archive.org/web/20230712081031/https://cdrdv2.intel.com/v1/dl/getContent/630744 -O sinit.zip
     unzip sinit.zip
-    mv 630744_003/SNB_IVB_SINIT_20190708_PW.bin "${output_dir}/" 
+    mv 630744_002/SNB_IVB_SINIT_20190708_PW.bin "${output_dir}/" 
     
     popd || exit
 fi


### PR DESCRIPTION
Also fix path where file is found in zip.

Emergency bugfix since master doesn't build. Merging.
Will try to find archive somewhere else.

Fixes https://github.com/linuxboot/heads/issues/1915