### PR TITLE
bin/seed_package_mirror.sh: Update talos-2 -> UNTESTED_talos-2

### DIFF
--- a/bin/seed_package_mirror.sh
+++ b/bin/seed_package_mirror.sh
@@ -54,7 +54,7 @@ rm -rf packages/x86 packages/ppc64
 echo
 echo "Downloading packages..."
 make packages BOARD=qemu-coreboot-fbwhiptail-tpm1-hotp
-make packages BOARD=talos-2 # newt, PPC
+make packages BOARD=UNTESTED_talos-2 # newt, PPC
 make packages BOARD=librem_l1um_v2 # TPM2
 make packages BOARD=librem_l1um # coreboot 4.11
 make packages BOARD=x230-maximized # io386


### PR DESCRIPTION
Board name was changed due to being untested.  It still builds, so the packages still sync to mirrors for now.