### PR TITLE
BUGFIXes : luks-functions + oem-factory-reset: fix logic for nvme/non-nvme based LUKS partitions checks + Force GPG Comment under oem-factory-reset + reset nk3 secrets app when in-memory keygen

### DIFF
--- a/initrd/bin/kexec-select-boot
+++ b/initrd/bin/kexec-select-boot
@@ -75,7 +75,7 @@ if [ "$CONFIG_TPM2_TOOLS" = "y" ]; then
 		warn "Hash of TPM2 primary key handle does not exist"
 		warn "Please rebuild the TPM2 primary key handle hash by setting a default OS to boot."
 		warn "Select Options-> Boot Options -> Show OS Boot Menu -> <Pick OS> -> Make default"
-		#TODO: Simplify/Automatize TPM2 firmware upgrade process. Today: upgrade, reboot, reseal(type TPM owner pass), resign, boot
+		#TODO: Simplify/Automatize TPM2 firmware upgrade process. Today: upgrade, reboot, reseal(type TPM Owner Password), resign, boot
 		default_failed="y"
 		DEBUG "Hash of TPM2 primary key handle does not exist under $PRIMHASH_FILE"
 	fi

--- a/initrd/bin/oem-factory-reset
+++ b/initrd/bin/oem-factory-reset
@@ -1164,13 +1164,13 @@ if [ "$use_defaults" == "n" -o "$use_defaults" == "N" ]; then
 			}
 		done
 
-		echo -e "\nEnter Comment (Optional, to distinguish this key from others with same previous attributes. Must be smaller then 60 characters):"
-		read -r GPG_USER_COMMENT
-		while [[ ${#GPG_USER_COMMENT} -gt 60 ]]; do
-			{
-				echo -e "\nEnter Comment (Optional, to distinguish this key from others with same previous attributes. Must be smaller then 60 characters):"
-				read -r GPG_USER_COMMENT
-			}
+		echo -e "\nEnter Comment (Required: Use this to distinguish this key from others, e.g., its purpose or usage context. Must be 1-60 characters):"
+		while true; do
+			read -r GPG_USER_COMMENT
+			if [[ ${#GPG_USER_COMMENT} -ge 1 && ${#GPG_USER_COMMENT} -le 60 ]]; then
+				break
+			fi
+			echo -e "\nComment must be 1-60 characters long. Please try again:"
 		done
 	fi
 

--- a/initrd/bin/oem-factory-reset
+++ b/initrd/bin/oem-factory-reset
@@ -152,13 +152,13 @@ mount_boot() {
 reset_nk3_secret_app() {
 	TRACE_FUNC
 
-	# Reset Nitrokey 3 Secrets app with $ADMIN_PIN (default 12345678, or customised)
+	# Reset Nitrokey 3 Secrets app PIN with $ADMIN_PIN (default 12345678, or customised)
 	if lsusb | grep -q "20a0:42b2" && [ -x /bin/hotp_verification ]; then
 		echo
-		warn "Resetting Nitrokey 3's Secrets App with PIN. Physical presence (touch) will be required"
+		warn "Resetting Nitrokey 3's Secrets app with PIN. Physical presence (touch) will be required"
 		# TODO: change message when https://github.com/Nitrokey/nitrokey-hotp-verification/issues/41 is fixed
 		# Reset Nitrokey 3 secret app with PIN
-		# Do 3 attempts to reset Nitrokey 3 Secrets App if return code is 3 (no touch)
+		# Do 3 attempts to reset Nitrokey 3 Secrets app if return code is 3 (no touch)
 		for attempt in 1 2 3; do
 			if /bin/hotp_verification reset "${ADMIN_PIN}"; then
 				echo
@@ -168,7 +168,7 @@ reset_nk3_secret_app() {
 				if [ $error_code -eq 3 ] && [ $attempt -lt 3 ]; then
 					whiptail --msgbox "Nitrokey 3 requires physical presence: touch the dongle when requested" $HEIGHT $WIDTH --title "Nk3 cecrets app reset attempt: $attempt/3"
 				else
-					whiptail_error_die "Nitrokey 3's secrets app reset failed with error:$error_code. Contact Nitrokey support"
+					whiptail_error_die "Nitrokey 3's Secrets app reset failed with error:$error_code. Contact Nitrokey support"
 				fi
 			fi
 		done

--- a/initrd/bin/oem-factory-reset
+++ b/initrd/bin/oem-factory-reset
@@ -1284,6 +1284,8 @@ gpg --list-keys >/dev/null 2>&1
 
 #Generate keys in memory and copy to smartcard
 if [ "$GPG_GEN_KEY_IN_MEMORY" = "y" ]; then
+	# Reset Nitrokey 3 Secrets app before generating keys in memory
+	reset_nk3_secret_app
 	if [ "$GPG_ALGO" == "RSA" ]; then
 		# Generate GPG master key
 		generate_inmemory_RSA_master_and_subkeys

--- a/initrd/bin/tpmr
+++ b/initrd/bin/tpmr
@@ -302,7 +302,7 @@ tpm2_counter_inc() {
 
 tpm1_counter_create() {
 	TRACE_FUNC
-	# tpmr handles the TPM owner password (from cache or prompt), but all
+	# tpmr handles the TPM Owner Password (from cache or prompt), but all
 	# other parameters for TPM1 are passed directly, and TPM2 mimics the
 	# TPM1 interface.
 	prompt_tpm_owner_password

--- a/initrd/etc/functions
+++ b/initrd/etc/functions
@@ -83,7 +83,7 @@ confirm_gpg_card() {
 
 	#TODO: ideally, we ask for confirmation only once per boot session
 	#TODO: even change logic here to try first and then ask user to confirm if not found
-	#TODO: or ask GPG user PIN once and cache it for the rest of the boot session for reusal
+	#TODO: or ask GPG User PIN once and cache it for the rest of the boot session for reusal
 	# This is getting in the way of unattended stuff and GPG prompts are confusing anyway, hide them from user.
 
 	TRACE_FUNC

--- a/initrd/etc/luks-functions
+++ b/initrd/etc/luks-functions
@@ -14,7 +14,9 @@ list_local_luks_devices() {
 		if cryptsetup isLuks "$device"; then
 			DEBUG "Device $device is a LUKS device"
 			dev_name=$(basename "$device")
-			parent_dev_name=$(echo "$dev_name" | sed 's/[0-9]*$//')
+			# Dynamically determine parent device name
+			parent_dev_name=$(echo "$dev_name" | sed -E 's/(p?[0-9]+)$//') # Handles both NVMe (pX) and non-NVMe (X)
+			DEBUG "Derived parent device name: $parent_dev_name"
 			if [ -e "/sys/block/$parent_dev_name" ]; then
 				DEBUG "Device $device exists in /sys/block"
 				if ! stat -c %N "/sys/block/$parent_dev_name" 2>/dev/null | grep -q "usb"; then
@@ -50,7 +52,7 @@ prompt_luks_passphrase() {
 # Test LUKS passphrase against all found LUKS containers that are not USB
 test_luks_passphrase() {
 	TRACE_FUNC
-
+	DEBUG "Testing LUKS passphrase against all found LUKS containers"
 	list_local_luks_devices >/tmp/luks_devices.txt
 	if [ ! -s /tmp/luks_devices.txt ]; then
 		warn "No LUKS devices found"
@@ -59,7 +61,7 @@ test_luks_passphrase() {
 
 	valid_luks_devices=()
 	while read -r luks_device; do
-		DEBUG "Testing passphrase on $luks_device"
+		DEBUG "Testing passphrase on device: $luks_device"
 		if cryptsetup open --test-passphrase "$luks_device" --key-file /tmp/secret/luks_current_Disk_Recovery_Key_passphrase; then
 			DEBUG "Passphrase valid for $luks_device"
 			valid_luks_devices+=("$luks_device")
@@ -69,10 +71,11 @@ test_luks_passphrase() {
 	done </tmp/luks_devices.txt
 
 	if [ ${#valid_luks_devices[@]} -eq 0 ]; then
+		DEBUG "No valid LUKS devices found with the provided passphrase"
 		return 1
 	fi
 
-	# Export the valid LUKS devices
+	DEBUG "Valid LUKS devices found: ${valid_luks_devices[*]}"
 	export LUKS="${valid_luks_devices[*]}"
 	return 0
 }
@@ -80,6 +83,7 @@ test_luks_passphrase() {
 # Confirm with the user to use all unlockable LUKS partitions
 confirm_luks_partitions() {
 	TRACE_FUNC
+	DEBUG "Confirming with the user to use all unlockable LUKS partitions"
 	MSG="The following LUKS partitions can be unlocked:\n\n${LUKS}\n\nDo you want to use all of these partitions?"
 	if [ -x /bin/whiptail ]; then
 		if ! whiptail --title "Confirm LUKS Partitions" --yesno "$MSG" 0 80; then
@@ -92,6 +96,7 @@ confirm_luks_partitions() {
 			die "User aborted the operation"
 		fi
 	fi
+	DEBUG "User confirmed LUKS partitions: $LUKS"
 }
 
 # Main function to prompt for passphrase, test it, and confirm partitions


### PR DESCRIPTION
Fixes #1944 #1949 #1951

---

### important
#1944 deserves a hotfix since no nvme can be reencrypted as part of re-ownership as of master
other fixes important too, but since in-memory keygen is not widely used, less important

----

- Finding and validating LUKS partitions key passphrase prior of re-encryption/passphrase change on NVME-Non-NVME drives was broken (still confused on how all tests past...) #1944
  - that function is used by UX for re-encryption + passphrase change (LUKS options)
  - that function is used under oem-factory-reset script (OEM Factory Reset/Re-Ownership)
- oem-factory-reset: GPG Comment is not optional. Force size 1-60 + tips on giving a good Comment (use case, purpose) #1949 
  - Note that OEM Factory Reset mode generates the comment automatically
    - Bug only triggered when user refuses defaults, answers that he wants to customize gpg key properties, but gave an empty comment. 
    - Reported, troubleshooted and tested under [Dasharo Premier Support Channel thread (invite only)](https://matrix.to/#/!RNcjJXCGHiyxXCHpKv:matrix.org/$kHIJQ9MjNQAyCw4MX3z_RFMU4cXtYgLXAVxyJsLe3d8?via=matrix.org&via=nitro.chat&via=tchncs.de) 
- oem-factory-reset: in-memory keygen + copy to smartcard + private keys backup was not enforcing nk3 secrets app #1951 
  - add missing call to reset_nk3_secret_app when that option is selected in questionnaire
    - reported, troubleshooted and fixed under  [Dasharo Premier Support Channel thread (invite only)](https://matrix.to/#/!RNcjJXCGHiyxXCHpKv:matrix.org/$PMVLy1gZa6CDZCT_-tcYSBp4lW4XhFtdz8Wamw2GkPg?via=matrix.org&via=nitro.chat&via=tchncs.de)
    - This means this feature is not used by a lot :(. But starts to :)