### PR TITLE
bugfix: modules/coreboot + blobs/xx80: rely on github for git, not review.coreboot.org

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -192,13 +192,13 @@ jobs:
           key: nix-docker-heads-coreboot-musl-cross-make-{{ checksum "./tmpDir/coreboot_musl-cross-make.sha256sums" }}{{ .Environment.CACHE_VERSION }}
           paths:
             - build/ppc64/coreboot-talos_2
-            - build/ppc64/musl-cross-make-38e52db8358c043ae82b346a2e6e66bc86a53bc1
+            - build/ppc64/musl-cross-make-fd6be58297ee21fcba89216ccd0d4aca1e3f1c5c
             - build/x86/coreboot-4.11
             - build/x86/coreboot-24.02.01
             - build/x86/coreboot-24.12
             - build/x86/coreboot-dasharo
             - build/x86/coreboot-purism
-            - build/x86/musl-cross-make-38e52db8358c043ae82b346a2e6e66bc86a53bc1
+            - build/x86/musl-cross-make-fd6be58297ee21fcba89216ccd0d4aca1e3f1c5c
             - crossgcc
             - packages
       - save_cache:

--- a/blobs/xx80/download_clean_deguard_me_pad_tb.sh
+++ b/blobs/xx80/download_clean_deguard_me_pad_tb.sh
@@ -90,7 +90,7 @@ function deguard() {
 
 	# Download the deguard tool into a temporary directory and apply the patch to the cleaned ME blob.
 	pushd "$(mktemp -d)" || exit
-	git clone https://review.coreboot.org/deguard.git
+	git clone https://github.com/coreboot/deguard
 	pushd deguard || exit
 	git checkout 0ed3e4ff824fc42f71ee22907d0594ded38ba7b2
 

--- a/modules/coreboot
+++ b/modules/coreboot
@@ -104,7 +104,7 @@ $(eval $(call coreboot_module,dasharo,24.02.01))
 # Therefore, patches/coreboot-2412 includes libreboot patches applied to 24.12 release
 #  patches/coreboot-2412 also includes PR0 patchset, minus xeon support which don't apply to 24.12 as per https://review.coreboot.org/c/coreboot/+/85278
 #   TODO: @miczyg1 rebase of patchset so that doenstream don't have to maintain, adapt work
-coreboot-24.12_repo := https://review.coreboot.org/coreboot.git
+coreboot-24.12_repo := https://github.com/coreboot/coreboot
 coreboot-24.12_commit_hash := 2f1e4e5e8515dd350cc9d68b48d32a5b6b02ae6a
 #Don't reuse any coreboot buildstack for now since nothing else is based on 24.12
 $(eval $(call coreboot_module,24.12,))


### PR DESCRIPTION
Fixes: #1946 #1948 

https://review.coreboot.org is having HTTPS issue. Reported on coreboot matrix channel, but need to build.

Log from CircleCI failing when trying to pull deguard: https://app.circleci.com/pipelines/github/tlaurion/heads/3267/workflows/588f8aeb-4d73-4f71-9e6e-fd286e46353e/jobs/66442/parallel-runs/0/steps/0-111

Reasoning:
We might dislike GitHub, but when comes maintaining a project and using free systems for bandwidth and CI because reproducibility and prosperity needed in time/cost efficiency, we need to rely on systems that don't randomly fall. 
Using GitHub mirrors fulfills that purpose here.