### PR TITLE
CircleCI: first layer cache: musl-cross-make+packages downloaded, was still pointing to old musl-cross-make

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ jobs:
       - run:
           name: Creating musl-cross-make and musl-cross-make patches digest (musl-cross-make cache digest)
           command: |
-            find .circleci/config.yml ./Makefile ./flake.lock modules/musl-cross-make* -type f | sort -h | xargs sha256sum > ./tmpDir/musl-cross-make.sha256sums
+            find ./flake.lock modules/musl-cross-make* -type f | sort -h | xargs sha256sum > ./tmpDir/musl-cross-make.sha256sums
       - restore_cache:
           # First matched/found key wins and following keys are not tried
           keys:
@@ -182,8 +182,8 @@ jobs:
           # CircleCI removed their wildcard support, so we have to list precise versions to cache in directory names
           key: nix-docker-heads-musl-cross-make-{{ checksum "./tmpDir/musl-cross-make.sha256sums" }}{{ .Environment.CACHE_VERSION }}
           paths:
-            - build/ppc64/musl-cross-make-38e52db8358c043ae82b346a2e6e66bc86a53bc1
-            - build/x86/musl-cross-make-38e52db8358c043ae82b346a2e6e66bc86a53bc1
+            - build/ppc64/musl-cross-make-fd6be58297ee21fcba89216ccd0d4aca1e3f1c5c
+            - build/x86/musl-cross-make-fd6be58297ee21fcba89216ccd0d4aca1e3f1c5c
             - crossgcc
             - packages
       - save_cache:


### PR DESCRIPTION
Fixes https://github.com/linuxboot/heads/issues/1948 (hopefully for real this time)

---

First layer cache of CircleCI is reused when more complete cache reusal are invalidated: that is, to not compiled musl-cross-make from source for x86/ppc64 at each build when any other thing changed under Heads.

Unfortunately, https://github.com/linuxboot/heads/pull/1947 was incomplete in that regard, as showed per build:
- last save cache step https://app.circleci.com/pipelines/github/tlaurion/heads/3270/workflows/07dee00e-926e-4023-b8a7-669078e6ef31/jobs/66483
  - first layer cache saving https://app.circleci.com/pipelines/github/tlaurion/heads/3270/workflows/07dee00e-926e-4023-b8a7-669078e6ef31/jobs/66483
    - Warning: could not archive /root/heads/build/ppc64/musl-cross-make-38e52db8358c043ae82b346a2e6e66bc86a53bc1 - Not found
    - Warning: could not archive /root/heads/build/x86/musl-cross-make-38e52db8358c043ae82b346a2e6e66bc86a53bc1 - Not found

It is also irrelevant to bind first layer cache with .circleci/config.yml, nor Makefile related changes. After all the first layer is related to reusing musl-cross-make to reduce build times on CI Therefore, only flake.lock and modules/musl-cross-make is relevant to be part of hashed files that should nto change to construct/reuse that cache