### PR TITLE
UX bugfix: kexec-save-default: suppress "Failed to set up async io, using sync io" warning thrown by lvm vgscan

### DIFF
--- a/initrd/bin/kexec-save-default
+++ b/initrd/bin/kexec-save-default
@@ -38,7 +38,7 @@ PRIMHASH_FILE="$paramsdir/kexec_primhdl_hash.txt"
 KEY_DEVICES="$paramsdir/kexec_key_devices.txt"
 KEY_LVM="$paramsdir/kexec_key_lvm.txt"
 
-lvm_suggest=$(lvm vgscan | awk -F '"' {'print $1'} | tail -n +2)
+lvm_suggest=$(lvm vgscan 2>/dev/null | awk -F '"' {'print $1'} | tail -n +2)
 num_lvm=$(echo "$lvm_suggest" | wc -l)
 if [ "$num_lvm" -eq 1 ] && [ -n "$lvm_suggest" ]; then
 	lvm_volume_group="$lvm_suggest"

--- a/initrd/etc/luks-functions
+++ b/initrd/etc/luks-functions
@@ -8,7 +8,7 @@
 # List all LUKS devices on the system that are not USB
 list_local_luks_devices() {
 	TRACE_FUNC
-	lvm vgscan || true
+	lvm vgscan 2>/dev/null || true
 	blkid | cut -d ':' -f 1 | while read -r device; do
 		DEBUG "Checking device: $device"
 		if cryptsetup isLuks "$device"; then


### PR DESCRIPTION
Fixes #1957 

under saving default boot option (not appearing anymore)
![2025-04-16-110305](https://github.com/user-attachments/assets/f3a2a58c-504b-4234-8fd0-dd500edd3175)

under oem-factory-reset, when saying N to defaults and Y to either changing LUKS passphrase/ reencrypting (not appearing anymore):
![2025-04-16-112636](https://github.com/user-attachments/assets/ccc8cbfb-ad91-436f-bb76-6b75136c68f0)

----

TODO: eventually refactor this out or silence no encrypted lvm found echos in code: who use encrypted LVM nowadays? I think this was pre QubesOS 3.2 era but not even sure anymore.
