### PR TITLE
patches/coreboot-24.12/0010-cbmem_tpm-clear_whole_log_on_creation.patch: readd missing uptream cbmem patch for TPM 1.2

### DIFF
--- a/patches/coreboot-24.12/0010-cbmem_tpm-clear_whole_log_on_creation.patch
+++ b/patches/coreboot-24.12/0010-cbmem_tpm-clear_whole_log_on_creation.patch
@@ -1,0 +1,37 @@
+From b83a7607203d285b76e94ffd2013c55b184f5d42 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Micha=C5=82=20=C5=BBygowski?= <michal.zygowski@3mdeb.com>
+Date: Wed, 30 Oct 2024 10:50:37 +0100
+Subject: [PATCH] security/tpm/tspi/log-tpm1.c: Clear whole log area on
+ creation
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The log area was not entirely cleared on creation resulting in
+garbage after the last valid lgo entry. It caused the cbmem utility
+to parse invalid events and access data outside the log area.
+In the TPM2 log sources, the entire area is being cleared, thus the
+issue has not been observed.
+
+Change-Id: I7c780b62b1c6507e1dd1806b20b0270e364cde3d
+Signed-off-by: Michał Żygowski <michal.zygowski@3mdeb.com>
+---
+ src/security/tpm/tspi/log-tpm1.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/security/tpm/tspi/log-tpm1.c b/src/security/tpm/tspi/log-tpm1.c
+index 481b569cd5..453e74b4e8 100644
+--- a/src/security/tpm/tspi/log-tpm1.c
++++ b/src/security/tpm/tspi/log-tpm1.c
+@@ -33,7 +33,7 @@ void *tpm1_log_cbmem_init(void)
+ 		if (!tclt)
+ 			return NULL;
+ 
+-		memset(tclt, 0, sizeof(*tclt));
++		memset(tclt, 0, tpm_log_len);
+ 		hdr = &tclt->spec_id;
+ 
+ 		/* Fill in first "header" entry. */
+-- 
+2.39.5
+


### PR DESCRIPTION
Fixes https://github.com/linuxboot/heads/issues/1956

This is is still unmerged coreboot upstream since 24.02.01 (meaning more than a year now: February 2024) : https://review.coreboot.org/c/coreboot/+/84926

Cleaner solution would be to clear whole area on creation: https://review.coreboot.org/c/coreboot/+/84927, but this patch doesn't apply cleanly and is not even under review yet. 

@marmarek let me know if that fixes it for you. I cannot reproduce on my side aymore.