### PR TITLE
Fix CicleCI cache usage; add docker proc tools for debugging (flake.nix + docker 0.2.5 upload)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -219,7 +219,7 @@ workflows:
       # This step builds musl-cross-make for x86 architecture, which will be used by subsequent x86 board builds
       - build_and_persist:
           name: x86-musl-cross-make
-          target: x230-hotp-maximized
+          target: t480-hotp-maximized
           subcommand: "musl-cross-make"
           requires:
             - prep_env

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ commands:
 jobs:
   prep_env:
     docker:
-      - image: tlaurion/heads-dev-env:v0.2.4
+      - image: tlaurion/heads-dev-env:v0.2.5
     resource_class: large
     working_directory: ~/heads
     steps:
@@ -122,7 +122,7 @@ jobs:
 
   build_and_persist:
     docker:
-      - image: tlaurion/heads-dev-env:v0.2.4
+      - image: tlaurion/heads-dev-env:v0.2.5
     resource_class: large
     working_directory: ~/heads
     parameters:
@@ -150,7 +150,7 @@ jobs:
 
   build:
     docker:
-      - image: tlaurion/heads-dev-env:v0.2.4
+      - image: tlaurion/heads-dev-env:v0.2.5
     resource_class: large
     working_directory: ~/heads
     parameters:
@@ -171,7 +171,7 @@ jobs:
 
   save_cache:
     docker:
-      - image: tlaurion/heads-dev-env:v0.2.4
+      - image: tlaurion/heads-dev-env:v0.2.5
     resource_class: large
     working_directory: ~/heads
     steps:

--- a/flake.nix
+++ b/flake.nix
@@ -24,7 +24,7 @@
         autoconf
         automake
         bashInteractive
-        coreutils
+        coreutils #basic tools like ls, cp, mv, kill)
         bc
         bison # Generate flashmap descriptor parser
         bzip2
@@ -58,6 +58,8 @@
         patch
         perl
         pkg-config
+        procps #process tools like free, pidof, pkill, top, vmstat, watch, etc
+        psmisc #process tools like killall, pstree, etc
         python3 # me_cleaner, coreboot
         rsync # coreboot
         sharutils

--- a/modules/musl-cross-make
+++ b/modules/musl-cross-make
@@ -35,7 +35,7 @@ else
 # No need to build i386 for x86 since coreboot uses its own compiler
 musl-cross-make_configure := \
 	echo -e >> Makefile 'musl-target:' ; \
-	echo -e >> Makefile '\t$$$$(MAKE) TARGET="$(MUSL_ARCH)-linux-musl" install' ;
+	echo -e >> Makefile '\t$$(MAKE) TARGET="$(MUSL_ARCH)-linux-musl" install' ;
 
 CROSS_PATH ?= $(pwd)/crossgcc/$(CONFIG_TARGET_ARCH)
 


### PR DESCRIPTION
Fix bug for cache reuse introduce when switching from x230 -> t480 for first board being build (but not switching x230->t480 for musl-cross-make at the same time under https://github.com/linuxboot/heads/pull/1908)

Test made from this PR:
- Reusal of stage 1 cache only (musl-cross-make cache)  workflow https://app.circleci.com/pipelines/github/tlaurion/heads/3314/workflows/e588480d-d13a-49e0-a1b6-78fed839b70b
  - See prep_env step restoring first and smallest cache layer " nix-docker-heads-coreboot-musl-cross-make" at https://app.circleci.com/pipelines/github/tlaurion/heads/3314/workflows/e588480d-d13a-49e0-a1b6-78fed839b70b/jobs/67599/parallel-runs/0/steps/0-107
- We changed modules/musl-cross-make at pipeline https://app.circleci.com/pipelines/github/tlaurion/heads/3315/workflows/9bc8a009-68c8-4547-9232-3ba3612ab0fb
  - No cache was existing, resulting in a clean build at https://app.circleci.com/pipelines/github/tlaurion/heads/3315/workflows/9bc8a009-68c8-4547-9232-3ba3612ab0fb/jobs/67645/parallel-runs/0/steps/0-107 which saved 3 layers of cache when successful
- Same commit was asked to be built from beginning, checking for cache existing https://app.circleci.com/pipelines/github/tlaurion/heads/3315/workflows/c66c8669-327a-42d9-822a-47b2dc87241e
  - A layer 3 cache (biggest) was found : "nix-docker-heads-modules-and-patches" at  https://app.circleci.com/pipelines/github/tlaurion/heads/3315/workflows/c66c8669-327a-42d9-822a-47b2dc87241e/jobs/67691/parallel-runs/0/steps/0-107

----
  
As said under #1666, we need insights on best next strategies to save cache/pass workspace caches under CircleCI per above links. Short version:
- No cache https://app.circleci.com/pipelines/github/tlaurion/heads/3315/workflows/9bc8a009-68c8-4547-9232-3ba3612ab0fb
  - restore cache step (prep_env) : 1m16s : no cache downloaded nor applied
  - musl-cross-make built from source: 16m36s
  - **total pipeline time: 1h24m (most of this time in compute time : no cache reused)**
- First layer cache reusal (msul-cross-make) https://app.circleci.com/pipelines/github/tlaurion/heads/3314/workflows/e588480d-d13a-49e0-a1b6-78fed839b70b
  - restore cache step (prep_env) : 9m2s
  - musl-cross-make cache reused step time: 11m43s : https://app.circleci.com/pipelines/github/tlaurion/heads/3314/workflows/e588480d-d13a-49e0-a1b6-78fed839b70b/jobs/67601
    - build time is still of 5m44s, rest is workspace download from prep_env step (attaching workspace step of 1m20s) and workspace creation (persisting to workspace step of  3m40s
    - **total build time : 1h24m29s (most of this time in computer time still for board builds but less cpu used because musl reused for ppc64/x86)**
 - third layer cache reusal (all built artifacts downloaded to minimize CPU build time) https://app.circleci.com/pipelines/github/tlaurion/heads/3315/workflows/c66c8669-327a-42d9-822a-47b2dc87241e
   - restore cache step (prep_env) : 16m9s
   - **t480-hotp-maximized : 18m30s here vs 42m6s: but only one board cache is used by arch right now**
   - total build time : 1h43m30s : we basically try to be more gentle for CircleCI CPU used time but do not economize much here and our board build time is less efficient than if we were not reusing any cache
     - To be efficient, we would need to: 
       - Have musl-cross-make built into docker image for architectures we support instead of rebuilding from source, and/or
       - Combine workspace cache layers per arch, then have save_Cache depend on that layer so we have the same gains of the single cahced board build layer we currently have but for all boards (this is currently 50% less build time whe board cache layer is used for talos-2 and t480, which layer is reused only for board depending on it, otherwise twice time spent in building from source all coreboot and modules