### PR TITLE
Makefile: make sure coreboot forks do the right thing when there is no .canary file but coreboot fork directory exists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -416,15 +416,15 @@ define define_module =
     # XXX: "git clean -dffx" is a hack for coreboot during commit switching, need
 	#      module-specific cleanup action to get rid of it.
     $(build)/$($1_base_dir)/.canary: FORCE
-	if [ ! -e "$$@" ]; then \
-		echo "INFO: .canary file not found. Cloning repository $($1_repo) into $(build)/$($1_base_dir)" && \
+	if [ ! -e "$$@" ] && [ ! -d "$(build)/$($1_base_dir)" ]; then \
+		echo "INFO: .canary file and directory not found. Cloning repository $($1_repo) into $(build)/$($1_base_dir)" && \
 		git clone $($1_repo) "$(build)/$($1_base_dir)" && \
 		echo "INFO: Resetting repository to commit $($1_commit_hash)" && \
 		git -C "$(build)/$($1_base_dir)" reset --hard $($1_commit_hash) && \
 		echo "INFO: Creating .canary file with repo and commit hash" && \
 		echo -n '$($1_repo)|$($1_commit_hash)' > "$$@" ; \
-	elif [ "$$$$(cat "$$@")" != '$($1_repo)|$($1_commit_hash)' ]; then \
-		echo "INFO: Canary file differs. Switching $1 to $($1_repo) at $($1_commit_hash)" && \
+	elif [ ! -e "$$@" ] || [ "$$$$(cat "$$@")" != '$($1_repo)|$($1_commit_hash)' ]; then \
+		echo "INFO: .canary file missing or differs. Resetting $1 to $($1_repo) at $($1_commit_hash)" && \
 		git -C "$(build)/$($1_base_dir)" reset --hard HEAD^ && \
 		echo "INFO: Fetching commit $($1_commit_hash) from $($1_repo) (without recursing submodules)" && \
 		git -C "$(build)/$($1_base_dir)" fetch $($1_repo) $($1_commit_hash) --recurse-submodules=no && \


### PR DESCRIPTION
Improves collaboration with Makefile real.remove_canary_files-extract_patch_rebuild_what_changed helper:
- if canary is not found but coreboot fork directory exists: do not attempt to git clone; git reset instead and reuse previous logic (try to apply patches since .patched got wipe, if fails, revert patches and reapply, and build clean while reusing past built artifacts to reduced build time). Typically builds everything from source while reusing reusable built objects within 5 minutes on my machine.
- if canary is not found and coreboot dir doesn't exist: git clone and build clean (meaning also rebuilding buildstack, version reusable build artifacts and boards artifacts clean, which is what takes 45 minutes per board, clean, on CircleCI).

Fix issues when building multiple boards not using the same coreboot fork and using the 
`./docker_repro.sh make BOARD=xyz real.remove_canary_files-extract_patch_rebuild_what_changed`

Note:
real.remove_canary_files-extract_patch_rebuild_what_changed wipes all .canary files, where previous coreboot .canary logic was cloning git repo if .canary was missing, resulting in an error.


Improves on https://github.com/linuxboot/heads/pull/1953 prior work