### PR TITLE
Makefile: initrd refactoring and data.cpio simplification

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,11 +179,12 @@ endif
 
 
 # Create a temporary directory for the initrd
-initrd_dir	:= $(BOARD)
-initrd_tmp_dir	:= $(shell mktemp -d)
-initrd_lib_dir	:= $(initrd_tmp_dir)/lib
-initrd_bin_dir	:= $(initrd_tmp_dir)/bin
-initrd_data_dir	:= $(initrd_tmp_dir)/data
+initrd_dir		:= $(BOARD)
+initrd_tmp_dir		:= $(shell mktemp -d)
+initrd_tools_dir	:= $(initrd_tmp_dir)/tools
+initrd_lib_dir		:= $(initrd_tools_dir)/lib
+initrd_bin_dir		:= $(initrd_tools_dir)/bin
+initrd_data_dir		:= $(initrd_tmp_dir)/data
 modules-y += initrd
 
 $(shell mkdir -p "$(initrd_lib_dir)" "$(initrd_bin_dir)" "$(initrd_data_dir)")
@@ -754,12 +755,12 @@ initrd-$(CONFIG_HEADS) += $(build)/$(initrd_dir)/heads.cpio
 #   1: Source file path
 #   2: Destination path inside the initrd
 define stage_data_file =
-$(initrd_tmp_dir)/data/$2: $1
+$(initrd_data_dir)/$2: $1
 	$(call do,INSTALL-DATA,$(1:$(pwd)/%=%) => $2,\
-		mkdir -p "$(dir $(initrd_tmp_dir)/data/$2)"; \
-		cp -a --remove-destination "$1" "$(initrd_tmp_dir)/data/$2"; \
+		mkdir -p "$(dir $(initrd_data_dir)/$2)"; \
+		cp -a --remove-destination "$1" "$(initrd_data_dir)/$2"; \
 	)
-data_initrd_files += $(initrd_tmp_dir)/data/$2
+data_initrd_files += $(initrd_data_dir)/$2
 endef
 
 # Iterate over each data_files entry: format is "src_path|dest_path"
@@ -781,9 +782,8 @@ $(foreach entry,$(data_files),\
 # Unified data.cpio rule: build all data files, then create cpio archive, then cleanup
 ifneq ($(strip $(data_files)),)
 $(build)/$(initrd_dir)/data.cpio: $(data_initrd_files) FORCE
-	@mkdir -p "$(initrd_tmp_dir)/data"
-	$(call do-cpio,$@,$(initrd_tmp_dir)/data)
-	@$(RM) -rf "$(initrd_tmp_dir)/data"
+	$(call do-cpio,$@,$(initrd_data_dir))
+	@$(RM) -rf "$(initrd_data_dir)"
 initrd-y += $(build)/$(initrd_dir)/data.cpio
 endif
 
@@ -795,21 +795,21 @@ endif
 
 # --- TOOLS.CPIO ---
 
-# tools.cpio is built from all binaries, libraries, and config staged in initrd_tmp_dir
+# tools.cpio is built from all binaries, libraries, and config staged in initrd_tools_dir
 $(build)/$(initrd_dir)/tools.cpio: \
 	$(initrd_bins) \
 	$(initrd_libs) \
-	$(initrd_tmp_dir)/etc/config \
+	$(initrd_tools_dir)/etc/config \
 	FORCE
-	$(call do-cpio,$@,$(initrd_tmp_dir))
-	@$(RM) -rf "$(initrd_tmp_dir)"
+	$(call do-cpio,$@,$(initrd_tools_dir))
+	@$(RM) -rf "$(initrd_tools_dir)"
 
 # --- TOOLS.CPIO'S ETC/CONFIG  ---
 #	This is board's config provided defaults (at compilation time)
 #  Those defaults can be overriden by cbfs' config.user applied at init through cbfs-init.
 #   To view overriden exports at runtime, simply run 'env' and review CONFIG_ exported variables
 #   To view compilation time board's config; check /etc/config under recovery shell.
-$(initrd_tmp_dir)/etc/config: FORCE
+$(initrd_tools_dir)/etc/config: FORCE
 	@mkdir -p $(dir $@)
 	$(call do,INSTALL,$(CONFIG), \
 		export \

--- a/modules/busybox
+++ b/modules/busybox
@@ -21,7 +21,7 @@ ifeq "$(CONFIG_BUSYBOX)" "y"
 initrd_bins += $(initrd_bin_dir)/busybox
 endif
 
-$(initrd_tmp_dir)/bin/busybox: $(build)/$(busybox_dir)/.build
+$(initrd_bin_dir)/busybox: $(build)/$(busybox_dir)/.build
 	$(call do,SYMLINK,bin/busybox,\
 		$(MAKE) \
 			-C $(build)/$(busybox_dir) \


### PR DESCRIPTION
Fixes #1969 in https://github.com/linuxboot/heads/commit/f9afeb71dda233aaafcd87a128e21660f455344a


data.cpio should have hash of 879be3583e8a7ad429e969cba378d000f36cfd7d11acbebda78c0f0bb94eab1f for most boards. 

Verified over Circleci t480, x230. And local builds. 

----

TLDR: kbd archive contained hardlinked files which cp -a --remove-destination was not able to reproducibly put in data temp dir.

---
Details : 
There was an issue where initrd_tmp_dir was used to create tools.cpio and wipe that dir, while data.cpio was subdirectory of initrd_tmp_dir. This PR seperates tools.cpio temp dir from data.cpio temp dir:
- tools.cpio:	initrd_tmp_dir/tools/{bin,lib}
- data.cpio:	initrd_tmp_dir/data

So that when wiping happens of a subdir, this doesn't affect others:
- initrd_tmp_dir = mktemp -d
- initrd_tools_dir = initrd_tmp_dir/tools
- initrd_bin_dir = initrd_tools_dir/bin
- initrd_lib_dir = initrd_tools_dir/lib
- initrd_data_dir = initrd_tmp_dir/data

This commit:
- Use proper variable names everywhere, no more initrd_tmp_dir.
  - initrd_tools_dir, initrd_lib_dir, initrd_bin_dir, initrd_data_dir
- change to busybox (initrd_tmp_dir/bin -> initrd_bin_dir) as well and review all other modules
- simplifies data files/dir registration and remove hardlink support: we want multiple copies of files that would be harlinked: cpio will be compressed to deduplicate. 