### PR TITLE
`qemu-coreboot-fbwhiptail-tpm1(-prod).config` coreboot config mismatch

### DIFF
--- a/boards/qemu-coreboot-fbwhiptail-tpm1-prod/qemu-coreboot-fbwhiptail-tpm1-prod.config
+++ b/boards/qemu-coreboot-fbwhiptail-tpm1-prod/qemu-coreboot-fbwhiptail-tpm1-prod.config
@@ -6,7 +6,7 @@ export CONFIG_COREBOOT=y
 export CONFIG_COREBOOT_VERSION=24.12
 export CONFIG_LINUX_VERSION=6.1.8
 
-CONFIG_COREBOOT_CONFIG=config/coreboot-qemu-tpm2-prod.config
+CONFIG_COREBOOT_CONFIG=config/coreboot-qemu-tpm1-prod.config
 CONFIG_LINUX_CONFIG=config/linux-qemu.config
 
 #Enable only one RESTRICTED/BASIC boot modes below to test them manually (we cannot inject config under QEMU (no internal flashing)

--- a/boards/qemu-coreboot-fbwhiptail-tpm1/qemu-coreboot-fbwhiptail-tpm1.config
+++ b/boards/qemu-coreboot-fbwhiptail-tpm1/qemu-coreboot-fbwhiptail-tpm1.config
@@ -6,7 +6,7 @@ export CONFIG_COREBOOT=y
 export CONFIG_COREBOOT_VERSION=24.12
 export CONFIG_LINUX_VERSION=6.1.8
 
-CONFIG_COREBOOT_CONFIG=config/coreboot-qemu-tpm2.config
+CONFIG_COREBOOT_CONFIG=config/coreboot-qemu-tpm1.config
 CONFIG_LINUX_CONFIG=config/linux-qemu.config
 
 #Enable only one RESTRICTED/BASIC boot modes below to test them manually (we cannot inject config under QEMU (no internal flashing)


### PR DESCRIPTION
`qemu-coreboot-fbwhiptail-tpm1` and `qemu-coreboot-fbwhiptail-tpm1-prod` use `coreboot-qemu-tpm2.config` and `coreboot-qemu-tpm2-prod.config` respectively.

This PR makes them use the qemu tmp1 coreboot config.