### PR TITLE
bin/seed_package_mirror.sh: dynamically seed all boards & toolchains

### DIFF
--- a/bin/seed_package_mirror.sh
+++ b/bin/seed_package_mirror.sh
@@ -48,17 +48,45 @@ cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
 echo
 echo "Cleaning build to download all packages..."
-# fetch packages for representative boards
-rm -rf build/x86 build/ppc64
-rm -rf packages/x86 packages/ppc64
+# Clear cached tarballs and .canary build stamps (modeled on the Makefile
+# real.remove_canary_files-extract_patch_rebuild_what_changed helper), so
+# module tarballs are re-downloaded and hash-verified AND coreboot forks
+# re-enter their build to produce the crossgcc toolchain tarballs that
+# seed the mirror.  Compiled artifacts are left intact — only the stamps
+# and cached sources that gate re-fetch are removed.
+rm -rf packages/*/*
+find build -type f -name ".canary" -delete 2>/dev/null || true
 echo
 echo "Downloading packages..."
-make packages BOARD=qemu-coreboot-fbwhiptail-tpm1-hotp
-make packages BOARD=UNTESTED_talos-2 # newt, PPC
-make packages BOARD=librem_l1um_v2 # TPM2
-make packages BOARD=EOL_librem_l1um # coreboot 4.11
-make packages BOARD=EOL_x230-maximized # io386
+# Discover all boards dynamically and fetch every module tarball.
+# 'make BOARD=X packages' triggers the 'packages:' target defined by
+# define_module (Makefile:571) for every versioned module that board
+# enables.  Tarballs are cached by filename in packages/<arch>/, so
+# redundant downloads for boards sharing tarballs cost only Make
+# setup overhead (~2s each).
+# A board that fails (e.g. dead upstream URL) is reported but does not
+# abort seeding the remaining boards.
+failed=0
+boards=()
+for cfg in boards/*/[!.]*.config; do
+	[ -f "$cfg" ] || continue
+	boards+=("$(basename "$(dirname "$cfg")")")
+done
+for board in "${boards[@]}"; do
+	echo "  make BOARD=$board packages"
+	# Redirect stdin from /dev/null so make/wget cannot consume the
+	# script's stdin — under set -e + if ! that can cause bash to
+	# misparse the loop and produce an intermittent syntax error.
+	if ! make BOARD="$board" packages </dev/null; then
+		echo "  WARNING: $board failed to fetch all packages" >&2
+		failed=$((failed+1))
+	fi
+done
+[ "$failed" -eq 0 ] || echo "Warning: $failed board(s) failed to fetch all packages" >&2
 echo
 echo "Copying to mirror directory..."
 mkdir -p "$ARG_MIRROR_DIR"
-cp packages/x86/* packages/ppc64/* "$ARG_MIRROR_DIR/"
+for arch_dir in packages/*/; do
+	[ -d "$arch_dir" ] || continue
+	cp "$arch_dir"* "$ARG_MIRROR_DIR/" 2>/dev/null || true
+done


### PR DESCRIPTION
Fixes #2177

## Problem

`bin/seed_package_mirror.sh` seeded the Purism package mirror using a
**hardcoded list of five representative boards**:

- `qemu-coreboot-fbwhiptail-tpm1-hotp` (base x86)
- `UNTESTED_talos-2` (PPC)
- `librem_l1um_v2` (TPM2)
- `EOL_librem_l1um` (coreboot 4.11)
- `EOL_x230-maximized` (io386)

After #2174 moved the musl-cross-make component tarballs under
`packages/`, the mirror did **not** get all of them cached on demand,
so builds served those 7 tarballs from the Purism mirror (`MIRROR_USED`
in `build/mirror_fallbacks.log`) rather than from primary sources.

The hardcoded list is also fragile: boards are added/renamed and
coreboot forks change over time, so the mirror was always at risk of
silently missing newly added module tarballs.

## Change

Rewrite `bin/seed_package_mirror.sh` to:

- **Discover all boards dynamically** via `boards/*/*.config` instead of a
  hardcoded list, so new boards, architectures, and coreboot forks are
  picked up automatically with no maintenance.
- **Run `make BOARD=<board> packages` for every board.** The `define_module`
  `packages:` target pre-downloads every versioned module tarball plus the
  coreboot crossgcc toolchain tarballs, which is what actually gets copied
  into the mirror.
- **Clean only the cached tarballs (`packages/*/*`) and `.canary` build
  stamps (`build/**/.canary`, modeled on the
  `real.remove_canary_files-extract_patch_rebuild_what_changed` Makefile
  helper)** so module tarballs are re-downloaded + hash-verified and
  coreboot forks re-emit their crossgcc toolchain, without wiping already
  compiled artifacts.
- **Redirect `make` stdin from `/dev/null`** to avoid an intermittent
  `bash: syntax error near unexpected token 'do'` that occurred under
  `set -e` + `if ! make ...` when `make`/`wget` consumed the script's stdin.
- **Tolerate per-board failures** (e.g. a dead upstream URL such as the
  coreboot 4.11 `acpica` tarball) without aborting the whole seed,
  reporting a summary of failed boards at the end.
- **Copy tarballs arch-agnostically** (`packages/*/`) instead of
  hardcoding `x86`/`ppc64`.

## Verification

- A full run over all boards completes with exit 0.
- Mirror contains the complete tarball set (90 files), including all 7
  musl-cross-make component tarballs that were the core of #2177.
- `build/mirror_fallbacks.log` shows the 7 musl-cross-make tarballs are now
  fetched from **primary** sources (`PRIMARY`) instead of `MIRROR_USED`.
- Coreboot forks are **not** fully re-cloned: clearing their `.canary`
  re-runs the Makefile branch that re-fetches the pinned commit and
  regenerates the `.canary` (observed: `.canary` present after the run,
  fork dirs preserved), yielding the crossgcc toolchain tarballs without a
  full re-clone.