### PR TITLE
modules/tpm-gpio-reset: cherry-pick platform support and attribution from heads-kano

### DIFF
--- a/modules/tpm-gpio-reset
+++ b/modules/tpm-gpio-reset
@@ -1,6 +1,10 @@
-# TPM GPIO Reset Vulnerability PoC (CVE-2025-32399 and related)
-# Minimal fork of kukrimate/tpm-gpio-fail: platform families + Makefile fixes only
-# Two binaries as in upstream kukri:
+# TPM GPIO Reset Vulnerability PoC (no CVE yet; Intel best-practices doc only).
+# Heads pins tlaurion/tpm-gpio-fail (Thierry Laurion): a Heads-leaning fork
+# of the original kukrimate/tpm-gpio-fail (Mate Kukri) PoC with extended
+# platform support. The pinned revision also carries platform and cleanup
+# commits from Kondix10/tpm-gpio-fail (Konrad Dadasiewicz): Alder Lake-N,
+# Elkhart Lake, Gemini Lake, Jasper Lake support and build/output fixups.
+# Two binaries, as in upstream kukri:
 #   tpm-gpio-detect   detection-only audit of GPIO lock status (no CLI args)
 #   tpm-gpio-assert   assertion/execute tool (kukri's modified coreboot inteltool)
 modules-$(CONFIG_TPM2_TOOLS) += tpm-gpio-reset

--- a/modules/tpm-gpio-reset
+++ b/modules/tpm-gpio-reset
@@ -7,7 +7,7 @@ modules-$(CONFIG_TPM2_TOOLS) += tpm-gpio-reset
 
 tpm-gpio-reset_depends := pciutils $(tpm2-tools_dep)
 tpm-gpio-reset_repo := https://github.com/tlaurion/tpm-gpio-fail.git
-tpm-gpio-reset_commit_hash := 8a9fc3a3c444d04674ef576a9d230d3881c86993
+tpm-gpio-reset_commit_hash := 3e3a695655b3b9e3188bb9aad70874dbcfb03145
 tpm-gpio-reset_version := $(tpm-gpio-reset_commit_hash)
 tpm-gpio-reset_base_dir := tpm-gpio-fail-$(tpm-gpio-reset_version)
 tpm-gpio-reset_dir := tpm-gpio-fail-$(tpm-gpio-reset_version)


### PR DESCRIPTION
Cherry-picks tpm-gpio-reset updates from tlaurion/heads-kano (google_kano-prejunkcleanup):

- **3fa1900a** — point module at 3e3a695: extended platform support (Alder Lake-N, Elkhart Lake, Gemini Lake, Jasper Lake) + inteltool cleanup fixup
- **4381c102** — attribute Kondix10 (Konrad Dadasiewicz) platform work in module header

The initial commit (3ebc60c8) was skipped — `modules/tpm-gpio-reset` is identical in master.

The attribution commit also corrects the module header: master incorrectly references CVE-2025-32399, but **there is no CVE yet**. The reference is Intel's public [GPIO Configuration Best Practices](https://www.intel.com/content/www/us/en/content-details/834810/gpio-configuration-best-practices.html) (ID 834810), which covers the PLTRSTB#/TPM reset issue, so the header now reads `(no CVE yet; Intel best-practices doc only)`.

Module now pins tlaurion/tpm-gpio-fail at 3e3a695 with full attribution chain (kukrimate → tlaurion → Kondix10).


----
Note that the old pulluted origin/main was moved to https://github.com/tlaurion/tpm-gpio-fail/tree/archive/main-polluted-20260626
